### PR TITLE
Snow bundle for Akeneo 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+/composer.lock
+/.idea/
+/.php-version

--- a/DependencyInjection/SnowioCsvConnectorExtension.php
+++ b/DependencyInjection/SnowioCsvConnectorExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class SnowioCsvConnectorExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('steps.yml');
+        $loader->load('writers.yml');
+        $loader->load('jobs.yml');
+        $loader->load('form_parameters.yml');
+        $loader->load('job_defaults.yml');
+        $loader->load('job_constraints.yml');
+    }
+}

--- a/DependencyInjection/SnowioCsvConnectorExtension.php
+++ b/DependencyInjection/SnowioCsvConnectorExtension.php
@@ -13,6 +13,7 @@ class SnowioCsvConnectorExtension extends Extension
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('steps.yml');
+        $loader->load('readers.yml');
         $loader->load('writers.yml');
         $loader->load('jobs.yml');
         $loader->load('form_parameters.yml');

--- a/Handler/ArchiveHandler.php
+++ b/Handler/ArchiveHandler.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Handler;
+
+use Akeneo\Component\Batch\Item\AbstractConfigurableStepElement;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+
+class ArchiveHandler extends AbstractConfigurableStepElement implements StepExecutionAwareInterface
+{
+    const ZIP_FILE_NAME = 'export.zip';
+
+    /** @var string */
+    protected $exportDir;
+    /** @var StepExecution */
+    private $stepExecution;
+
+    public function execute()
+    {
+        $zip = new \ZipArchive();
+        $location = rtrim($this->exportDir, '/') . DIRECTORY_SEPARATOR . self::ZIP_FILE_NAME;
+        $opened = $zip->open($location, \ZipArchive::CREATE);
+        if ($opened !== true) {
+            $this->stepExecution->addFailureException(new \RuntimeException('Failed to open zip, reason code:' . $opened));
+        } else {
+            $success = $zip->addPattern(
+                '/(?:\w+\.csv|metadata.json)/',
+                $this->exportDir,
+                ['add_path' => '/', 'remove_all_path' => true]
+            );
+            if (!$success) {
+                $this->stepExecution->addFailureException(new \RuntimeException('Failed to add files to zip.'));
+            }
+            $zip->close();
+            $this->stepExecution->addSummaryInfo('zip_location', $location);
+        }
+    }
+
+    public function getConfigurationFields()
+    {
+        return [
+            'exportDir' => [
+                'options' => [
+                    'label' => 'snowio_connector.form.exportDir.label',
+                    'help'  => 'snowio_connector.form.exportDir.help'
+                ]
+            ]
+        ];
+    }
+
+    public function setStepExecution(StepExecution $stepExecution)
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+    public function getExportDir()
+    {
+        return $this->exportDir;
+    }
+
+    public function setExportDir($exportDir)
+    {
+        $this->exportDir = $exportDir;
+    }
+}

--- a/Handler/MetadataHandler.php
+++ b/Handler/MetadataHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Handler;
+
+use Akeneo\Component\Batch\Item\AbstractConfigurableStepElement;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Snowio\Bundle\CsvConnectorBundle\SnowioCsvConnectorBundle;
+
+class MetadataHandler extends AbstractConfigurableStepElement implements StepExecutionAwareInterface
+{
+    /** @var StepExecution */
+    private $stepExecution;
+    /** @var  array */
+    private $configs;
+
+    public function execute()
+    {
+        $location = rtrim($this->configs['exportDir'], '/') . DIRECTORY_SEPARATOR . 'metadata.json';
+        file_put_contents(
+            $location,
+            json_encode([
+                'bundleVersion' => SnowioCsvConnectorBundle::VERSION,
+                'jobCode' => $this->stepExecution->getJobExecution()->getJobInstance()->getAlias(),
+                'date' => gmdate('Y-m-d_H:i:s'),
+                'channel' => $this->configs['channel'],
+                'delimiter' => $this->configs['delimiter'],
+                'enclosure' => $this->configs['enclosure'],
+                'withHeader' => $this->configs['withHeader'],
+                'decimalSeparator' => $this->configs['decimalSeparator'],
+                'dateFormat' => $this->configs['dateFormat'],
+            ])
+        );
+
+        $this->stepExecution->addSummaryInfo('metadata_location', $location);
+    }
+
+    public function getConfigurationFields()
+    {
+        return [];
+    }
+
+    public function setConfiguration(array $config)
+    {
+        parent::setConfiguration($config);
+        $this->configs = $config;
+
+    }
+
+    public function setStepExecution(StepExecution $stepExecution)
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+}

--- a/Handler/PostHandler.php
+++ b/Handler/PostHandler.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Handler;
+
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Component\Batch\Item\AbstractConfigurableStepElement;
+use GuzzleHttp\ClientInterface;
+
+class PostHandler extends AbstractConfigurableStepElement implements StepExecutionAwareInterface
+{
+    /** @var StepExecution */
+    protected $stepExecution;
+    /** @var string */
+    protected $url;
+    /** @var string */
+    protected $exportDir;
+    /** @var string */
+    protected $applicationId;
+    /** @var string */
+    protected $secretKey;
+    /** @var \GuzzleHttp\Client */
+    protected $client;
+
+    /**
+     * PostHandler constructor.
+     * @param \GuzzleHttp\ClientInterface $client
+     * @author Cristian Quiroz <cq@amp.co>
+     */
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @throws \Exception
+     * @author Cristian Quiroz <cq@amp.co>
+     */
+    public function execute()
+    {
+        $url = $this->getUrl() . $this->getApplicationId();
+        $this->stepExecution->addSummaryInfo('url', $url);
+
+        $resource = fopen(rtrim($this->exportDir, '/') . DIRECTORY_SEPARATOR . ArchiveHandler::ZIP_FILE_NAME, 'r');
+        
+        if (false === $resource) {
+            $this->stepExecution->addFailureException(new \RuntimeException('Failed to open file to send to snow.io'));
+            return;
+        }
+
+        $response = $this->client->request(
+            'POST',
+            $url,
+            [
+                'body'      => $resource,
+                'headers'   => [
+                    'Content-Type'          => 'application/zip',
+                    'Authorization'         => $this->getSecretKey(),
+                ],
+            ]
+        );
+
+        $this->stepExecution->addSummaryInfo('response_code', $response->getStatusCode());
+        $this->stepExecution->addSummaryInfo('response_body', $response->getBody());
+
+        if ($response->getStatusCode() !== 204) {
+//             Unexpected response, handle
+            $this->stepExecution->addFailureException(new \Exception('Failed to POST csv data: ' . $response->getBody()));
+        }
+
+    }
+
+    /**
+     * @param \Akeneo\Component\Batch\Model\StepExecution $stepExecution
+     * @author Cristian Quiroz <cq@amp.co>
+     */
+    public function setStepExecution(StepExecution $stepExecution)
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+    /**
+     * @param string $exportDir
+     * @return $this
+     * @author Cristian Quiroz <cq@amp.co>
+     */
+    public function setExportDir($exportDir)
+    {
+        $this->exportDir = $exportDir;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     * @author Cristian Quiroz <cq@amp.co>
+     */
+    public function getExportDir()
+    {
+        return $this->exportDir;
+    }
+
+    /**
+     * @return string
+     */
+    public function getApplicationId()
+    {
+        return $this->applicationId;
+    }
+
+    /**
+     * @param string $applicationId
+     * @return $this
+     */
+    public function setApplicationId($applicationId)
+    {
+        $this->applicationId = $applicationId;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSecretKey()
+    {
+        return $this->secretKey;
+    }
+
+    /**
+     * @param string $secretKey
+     * @return $this
+     */
+    public function setSecretKey($secretKey)
+    {
+        $this->secretKey = $secretKey;
+
+        return $this;
+    }
+
+    /**
+     * @param $url
+     * @return $this
+     * @author Cristian Quiroz <cq@amp.co>
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     * @author Cristian Quiroz <cq@amp.co>
+     */
+    public function getUrl()
+    {
+        return rtrim($this->url, '/') . '/';
+    }
+
+    /**
+     * Here, we define the form fields to use
+     * @return array
+     * @author Cristian Quiroz <cq@amp.co>
+     */
+    public function getConfigurationFields()
+    {
+        return [
+                'exportDir' => [
+                    'options' => [
+                        'label' => 'snowio_connector.form.exportDir.label',
+                        'help'  => 'snowio_connector.form.exportDir.help'
+                    ]
+                ],
+                'url' => [
+                    'type' => 'text',
+                    'required' => true,
+                    'options' => [
+                        'label' => 'snowio_connector.form.url.label',
+                        'help'  => 'snowio_connector.form.url.help'
+                    ],
+                ],
+                'applicationId' => [
+                    'type' => 'text',
+                    'required' => true,
+                    'options' => [
+                        'label' => 'snowio_connector.form.applicationId.label',
+                    ],
+                ],
+                'secretKey' => [
+                    'type' => 'password',
+                    'required' => true,
+                    'options' => [
+                        'label' => 'snowio_connector.form.secretKey.label',
+                    ],
+                ],
+            ];
+    }
+}

--- a/Job/JobParameters/ConstraintCollectionProvider/ConstraintTrait.php
+++ b/Job/JobParameters/ConstraintCollectionProvider/ConstraintTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Job\JobParameters\ConstraintCollectionProvider;
+
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Uuid;
+use Pim\Component\Catalog\Validator\Constraints\WritableDirectory;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\Collection;
+
+trait ConstraintTrait
+{
+    /**
+     * Extend with our fields and remove filePath
+     *
+     * @author Nei Santos <ns@amp.co>
+     * @return Collection
+     */
+    public function getConstraintCollection()
+    {
+        $constraintFields = parent::getConstraintCollection();
+        $simpleFields = $constraintFields->fields;
+
+        unset($simpleFields['filePath']);
+
+        return new Collection(['fields' => array_merge([
+            'endpoint'      => [
+                new NotBlank(['groups' => ['Default', 'FileConfiguration']]),
+                new Regex([
+                    'pattern' => '/^http(.*)\/$/',
+                    'message' => 'The endpoint should be an http url ending with slash. (http://localhost/)'
+                ])
+            ],
+            'applicationId' => [
+                new Uuid(['groups' => ['Default', 'FileConfiguration']]),
+                new NotBlank(['groups' => ['Default', 'FileConfiguration']])
+            ],
+            'secretKey'     => new NotBlank(['groups' => ['Default', 'FileConfiguration']]),
+            'exportDir'     => [
+                new NotBlank(['groups' => ['Default', 'Execution', 'FileConfiguration']]),
+                new WritableDirectory(['groups' => ['Execution', 'FileConfiguration']]),
+            ],
+            'rsyncDirectory'     => [],
+            'rsyncUser'     => [],
+            'rsyncHost'     => [],
+            'rsyncOptions'  => [],
+        ], $simpleFields)]);
+    }
+}

--- a/Job/JobParameters/ConstraintCollectionProvider/ProductConstraint.php
+++ b/Job/JobParameters/ConstraintCollectionProvider/ProductConstraint.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Job\JobParameters\ConstraintCollectionProvider;
+
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters\ConstraintCollectionProviderInterface;
+use Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\ProductCsvExport as BaseProductCsvExport;
+
+class ProductConstraint extends BaseProductCsvExport implements ConstraintCollectionProviderInterface
+{
+    use ConstraintTrait;
+
+    public function supports(JobInterface $job)
+    {
+        return in_array($job->getName(), $this->supportedJobNames);
+    }
+}

--- a/Job/JobParameters/ConstraintCollectionProvider/SimpleConstraint.php
+++ b/Job/JobParameters/ConstraintCollectionProvider/SimpleConstraint.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Job\JobParameters\ConstraintCollectionProvider;
+
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters\ConstraintCollectionProviderInterface;
+use Pim\Component\Connector\Job\JobParameters\ConstraintCollectionProvider\SimpleCsvExport as BaseSimpleCsvExport;
+
+class SimpleConstraint extends BaseSimpleCsvExport implements ConstraintCollectionProviderInterface
+{
+    use ConstraintTrait;
+
+    public function supports(JobInterface $job)
+    {
+        return in_array($job->getName(), $this->supportedJobNames);
+    }
+}

--- a/Job/JobParameters/DefaultValuesProvider/DefaultValuesTrait.php
+++ b/Job/JobParameters/DefaultValuesProvider/DefaultValuesTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Job\JobParameters\DefaultValuesProvider;
+
+trait DefaultValuesTrait
+{
+    /**
+     * Extend with default values to our fields and remove filePath
+     *
+     * @author Nei Santos <ns@amp.co>
+     * @return Collection
+     */
+    public function getDefaultValues()
+    {
+        $simpleDefaults = parent::getDefaultValues();
+
+        unset($simpleDefaults['filePath']);
+
+        return array_merge([
+            'endpoint'      => '',
+            'applicationId' => '',
+            'secretKey'     => '',
+            'exportDir'     => '',
+            'rsyncDirectory'=> '',
+            'rsyncUser'     => '',
+            'rsyncHost'     => '',
+            'rsyncOptions'  => [],
+        ], $simpleDefaults);
+    }
+}

--- a/Job/JobParameters/DefaultValuesProvider/ProductDefaultValues.php
+++ b/Job/JobParameters/DefaultValuesProvider/ProductDefaultValues.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Job\JobParameters\DefaultValuesProvider;
+
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
+use Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\ProductCsvExport as BaseProductCsvExport;
+
+class ProductDefaultValues extends BaseProductCsvExport implements DefaultValuesProviderInterface
+{
+    use DefaultValuesTrait;
+
+    public function supports(JobInterface $job)
+    {
+        return in_array($job->getName(), $this->supportedJobNames);
+    }
+}

--- a/Job/JobParameters/DefaultValuesProvider/SimpleDefaultValues.php
+++ b/Job/JobParameters/DefaultValuesProvider/SimpleDefaultValues.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Job\JobParameters\DefaultValuesProvider;
+
+use Akeneo\Component\Batch\Job\JobInterface;
+use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
+use Pim\Component\Connector\Job\JobParameters\DefaultValuesProvider\SimpleCsvExport as BaseSimpleCsvExport;
+
+class SimpleDefaultValues extends BaseSimpleCsvExport implements DefaultValuesProviderInterface
+{
+    use DefaultValuesTrait;
+
+    public function supports(JobInterface $job)
+    {
+        return in_array($job->getName(), $this->supportedJobNames);
+    }
+}

--- a/MediaExport/ExportLocation.php
+++ b/MediaExport/ExportLocation.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\MediaExport;
+
+class ExportLocation
+{
+    /** @var  string */
+    private $directory;
+
+    /** @var string|false */
+    private $host;
+
+    /** @var string|false */
+    private $user;
+
+    public function __construct($directory, $host = false, $user = false)
+    {
+        $this->directory = $directory;
+        $this->host = $host;
+        $this->user = $user;
+    }
+
+    /**
+     * @return string
+     */
+    public function toString()
+    {
+        if ($this->user && $this->host) {
+            return sprintf(
+                '%s@%s:%s',
+                $this->user,
+                $this->host,
+                $this->directory
+            );
+        }
+
+        if (!$this->user && $this->host) {
+            return sprintf(
+                '%s:%s',
+                $this->host,
+                $this->directory
+            );
+        }
+
+        return $this->directory;
+    }
+
+    public function setUser($user)
+    {
+        if (is_string($user) && !empty($user)) {
+            $this->user = $user;
+        }
+    }
+
+    public function setDirectory($directory)
+    {
+        if (is_string($directory) && !empty($directory)) {
+            $this->directory = $directory;
+        }
+    }
+
+    public function setHost($host)
+    {
+        if (is_string($host) && !empty($host)) {
+            $this->host = $host;
+        }
+    }
+}

--- a/MediaExport/Logger.php
+++ b/MediaExport/Logger.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\MediaExport;
+
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
+
+class Logger
+{
+    /** @var string */
+    private $logDirectory;
+    
+    /**
+     * @param string $logDirectory
+     */
+    public function __construct($logDirectory)
+    {
+        $this->logDirectory = $logDirectory;
+    }
+
+    /**
+     * @param array $content
+     * @param $jobId
+     */
+    public function writeLog(array $content, $jobId)
+    {
+        $logFile = $this->getLogFileNameForJob($jobId);
+
+        if (!is_dir(dirname($logFile))) {
+            mkdir(dirname($logFile), 0755, true);
+        }
+
+        $handle = fopen($logFile, 'a+');
+        if ($handle === false) {
+            throw new FileNotFoundException(
+                sprintf('Error - log file (%s) could not be opened during media export.', $logFile)
+            );
+        }
+
+        fputcsv($handle, $content, PHP_EOL);
+        fclose($handle);
+    }
+
+    /**
+     * @param $jobId
+     * @return string
+     */
+    public function getLogFileNameForJob($jobId)
+    {
+        return rtrim($this->logDirectory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $jobId . '.log';
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# akeneo2-snow-bundle

--- a/Reader/Database/ProductModelReader.php
+++ b/Reader/Database/ProductModelReader.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Reader\Database;
+
+use Pim\Component\Connector\Reader\Database\ProductReader as BaseProductModelReader;
+
+class ProductModelReader extends BaseProductModelReader
+{
+    protected function getConfiguredFilters()
+    {
+        return [];
+    }
+}

--- a/Resources/config/form_extensions/snowio_product_export_edit.yml
+++ b/Resources/config/form_extensions/snowio_product_export_edit.yml
@@ -74,7 +74,7 @@ extensions:
         module: pim/job/common/edit/field/decimal-separator
         parent: snowio-csv-product-export-edit-properties
         position: 120
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.decimalSeparator
             readOnly: false
@@ -85,7 +85,7 @@ extensions:
         module: pim/job/product/edit/field/date-format
         parent: snowio-csv-product-export-edit-properties
         position: 130
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.dateFormat
             readOnly: false
@@ -96,7 +96,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-edit-properties
         position: 140
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.delimiter
             readOnly: false
@@ -107,7 +107,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-edit-properties
         position: 150
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.enclosure
             readOnly: false
@@ -118,7 +118,7 @@ extensions:
         module: pim/job/common/edit/field/switch
         parent: snowio-csv-product-export-edit-properties
         position: 160
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.withHeader
             readOnly: false
@@ -129,7 +129,7 @@ extensions:
         module: pim/job/common/edit/field/switch
         parent: snowio-csv-product-export-edit-properties
         position: 170
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.with_media
             readOnly: false
@@ -140,7 +140,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-edit-properties
         position: 180
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.endpoint
             readOnly: false
@@ -151,7 +151,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-edit-properties
         position: 190
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.applicationId
             readOnly: false
@@ -162,7 +162,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-edit-properties
         position: 200
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.secretKey
             readOnly: false
@@ -173,7 +173,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-edit-properties
         position: 210
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.exportDir
             readOnly: false
@@ -184,7 +184,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-edit-properties
         position: 220
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncDirectory
             readOnly: false
@@ -195,7 +195,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-edit-properties
         position: 230
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncUser
             readOnly: false
@@ -206,7 +206,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-edit-properties
         position: 240
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncHost
             readOnly: false
@@ -217,7 +217,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-edit-properties
         position: 240
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncOptions
             readOnly: false
@@ -235,15 +235,6 @@ extensions:
         parent: snowio-csv-product-export-edit
         targetZone: meta
         position: 100
-
-    snowio-csv-product-export-edit-back-to-grid:
-        module: pim/form/common/back-to-grid
-        parent: snowio-csv-product-export-edit
-        targetZone: back
-        aclResourceId: pim_importexport_export_profile_index
-        position: 80
-        config:
-            backUrl: pim_importexport_export_profile_index
 
     snowio-csv-product-export-edit-delete:
         module: pim/job/export/edit/delete

--- a/Resources/config/form_extensions/snowio_product_export_edit.yml
+++ b/Resources/config/form_extensions/snowio_product_export_edit.yml
@@ -1,0 +1,338 @@
+extensions:
+    snowio-csv-product-export-edit:
+        module: pim/form/common/edit-form
+
+    snowio-csv-product-export-edit-cache-invalidator:
+        module: pim/cache-invalidator
+        parent: snowio-csv-product-export-edit
+        position: 1000
+
+    snowio-csv-product-export-edit-tabs:
+        module: pim/form/common/form-tabs
+        parent: snowio-csv-product-export-edit
+        targetZone: content
+        position: 100
+
+    snowio-csv-product-export-edit-properties:
+        module: pim/job/common/edit/properties
+        parent: snowio-csv-product-export-edit-tabs
+        aclResourceId: pim_importexport_export_profile_property_edit
+        targetZone: container
+        position: 100
+        config:
+            tabTitle: pim_enrich.form.job_instance.tab.properties.title
+            tabCode: pim-job-instance-properties
+
+    snowio-csv-product-export-edit-content:
+        module: pim/job/product/edit/content
+        parent: snowio-csv-product-export-edit-tabs
+        aclResourceId: pim_importexport_export_profile_content_edit
+        targetZone: container
+        position: 110
+        config:
+            tabTitle: pim_enrich.form.job_instance.tab.content.title
+            tabCode: pim-job-instance-content
+
+    snowio-csv-product-export-edit-content-structure:
+        module: pim/job/product/edit/content/structure
+        parent: snowio-csv-product-export-edit-content
+        targetZone: structure-filters
+        position: 100
+
+    snowio-csv-product-export-edit-history:
+        module: pim/common/tab/history
+        parent: snowio-csv-product-export-edit-tabs
+        targetZone: container
+        aclResourceId: pim_importexport_export_profile_history
+        position: 120
+        config:
+            class: Akeneo\Component\Batch\Model\JobInstance
+            title: pim_enrich.form.job_instance.tab.history.title
+            tabCode: pim-job-instance-history
+
+    snowio-csv-product-export-edit-properties-code:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 100
+        targetZone: properties
+        config:
+            fieldCode: code
+            label: pim_enrich.form.job_instance.tab.properties.code.title
+            readOnly: true
+
+    snowio-csv-product-export-edit-properties-label:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 110
+        targetZone: properties
+        config:
+            fieldCode: label
+            label: pim_enrich.form.job_instance.tab.properties.label.title
+            readOnly: false
+
+    snowio-csv-product-export-edit-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
+        parent: snowio-csv-product-export-edit-properties
+        position: 120
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.decimalSeparator
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+
+    snowio-csv-product-export-edit-properties-date-format:
+        module: pim/job/product/edit/field/date-format
+        parent: snowio-csv-product-export-edit-properties
+        position: 130
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.dateFormat
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+
+    snowio-csv-product-export-edit-properties-delimiter:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 140
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.delimiter
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.delimiter.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
+
+    snowio-csv-product-export-edit-properties-enclosure:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 150
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.enclosure
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.enclosure.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
+
+    snowio-csv-product-export-edit-properties-with-header:
+        module: pim/job/common/edit/field/switch
+        parent: snowio-csv-product-export-edit-properties
+        position: 160
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.withHeader
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.with_header.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+
+    snowio-csv-product-export-edit-properties-with-media:
+        module: pim/job/common/edit/field/switch
+        parent: snowio-csv-product-export-edit-properties
+        position: 170
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.with_media
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.with_media.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
+
+    snowio-csv-product-export-edit-properties-endpoint:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 180
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.endpoint
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.endpoint.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.endpoint.help
+
+    snowio-csv-product-export-edit-properties-application-id:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 190
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.applicationId
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.application_id.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.application_id.help
+
+    snowio-csv-product-export-edit-properties-secret-key:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 200
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.secretKey
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.secret_key.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.secret_key.help
+
+    snowio-csv-product-export-edit-properties-export-dir:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 210
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.exportDir
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.export_dir.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.export_dir.help
+
+    snowio-csv-product-export-edit-properties-rsync-directory:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 220
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncDirectory
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_directory.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_directory.help
+
+    snowio-csv-product-export-edit-properties-rsync-user:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 230
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncUser
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_user.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_user.help
+
+    snowio-csv-product-export-edit-properties-rsync-host:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 240
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncHost
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_host.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_host.help
+
+    snowio-csv-product-export-edit-properties-rsync-options:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-edit-properties
+        position: 240
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncOptions
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_options.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_options.help
+
+    snowio-csv-product-export-edit-label:
+        module: pim/job/common/edit/label
+        parent: snowio-csv-product-export-edit
+        targetZone: title
+        position: 100
+
+    snowio-csv-product-export-edit-meta:
+        module: pim/job/common/edit/meta
+        parent: snowio-csv-product-export-edit
+        targetZone: meta
+        position: 100
+
+    snowio-csv-product-export-edit-back-to-grid:
+        module: pim/form/common/back-to-grid
+        parent: snowio-csv-product-export-edit
+        targetZone: back
+        aclResourceId: pim_importexport_export_profile_index
+        position: 80
+        config:
+            backUrl: pim_importexport_export_profile_index
+
+    snowio-csv-product-export-edit-delete:
+        module: pim/job/export/edit/delete
+        parent: snowio-csv-product-export-edit
+        targetZone: buttons
+        aclResourceId: pim_importexport_export_profile_remove
+        position: 100
+        config:
+            trans:
+                title: confirmation.remove.job_instance
+                content: pim_enrich.confirmation.delete_item
+                success: flash.job_instance.removed
+                failed: error.removing.job_instance
+            redirect: pim_importexport_export_profile_index
+
+    snowio-csv-product-export-edit-save-buttons:
+        module: pim/form/common/save-buttons
+        parent: snowio-csv-product-export-edit
+        targetZone: buttons
+        position: 120
+
+    snowio-csv-product-export-edit-save:
+        module: pim/job-instance-export-edit-form/save
+        parent: snowio-csv-product-export-edit
+        targetZone: buttons
+        position: 0
+        config:
+            redirectPath: pim_importexport_export_profile_show
+
+    snowio-csv-product-export-edit-state:
+        module: pim/form/common/state
+        parent: snowio-csv-product-export-edit
+        targetZone: state
+        position: 900
+        config:
+            entity: pim_enrich.entity.job_instance.title
+
+    snowio-csv-product-export-edit-content-structure-scope:
+        module: pim/job/product/edit/content/structure/scope
+        parent: snowio-csv-product-export-edit-content-structure
+        targetZone: filters
+        position: 90
+
+    snowio-csv-product-export-edit-content-structure-locales:
+        module: pim/job/product/edit/content/structure/locales
+        parent: snowio-csv-product-export-edit-content-structure
+        targetZone: filters
+        position: 100
+
+    snowio-csv-product-export-edit-content-structure-attributes:
+        module: pim/job/product/edit/content/structure/attributes
+        parent: snowio-csv-product-export-edit-content-structure
+        targetZone: filters
+        position: 110
+
+    snowio-csv-product-export-edit-content-data:
+        module: pim/job/product/edit/content/data
+        parent: snowio-csv-product-export-edit-content
+        targetZone: data-filters
+        config:
+            filters:
+                -
+                    field: family
+                    view: akeneo-product-family-filter
+                -
+                    field: enabled
+                    view: akeneo-product-enabled-filter
+                -
+                    field: completeness
+                    view: akeneo-product-completeness-filter
+                -
+                    field: updated
+                    view: akeneo-product-updated-filter
+                -
+                    field: categories
+                    view: akeneo-product-category-filter
+
+    snowio-csv-product-export-edit-content-default-attribute-filters:
+        module: pim/job/product/edit/content/data/default-attribute-filters
+        parent: snowio-csv-product-export-edit-content-data
+        config:
+            types: [pim_catalog_identifier]
+
+    snowio-csv-product-export-edit-validation:
+        module: pim/job/common/edit/validation
+        parent: snowio-csv-product-export-edit
+
+    snowio-csv-product-export-edit-content-data-add-filter:
+        module: pim/job/product/edit/content/data/add-select/attribute
+        parent: snowio-csv-product-export-edit-content-data
+        targetZone: headings
+        position: 90

--- a/Resources/config/form_extensions/snowio_product_export_show.yml
+++ b/Resources/config/form_extensions/snowio_product_export_show.yml
@@ -1,0 +1,311 @@
+extensions:
+    snowio-csv-product-export-show:
+        module: pim/form/common/edit-form
+
+    snowio-csv-product-export-show-tabs:
+        module: pim/form/common/form-tabs
+        parent: snowio-csv-product-export-show
+        targetZone: content
+        position: 100
+
+    snowio-csv-product-export-show-properties:
+        module: pim/job/common/edit/properties
+        parent: snowio-csv-product-export-show-tabs
+        aclResourceId: pim_importexport_export_profile_property_show
+        targetZone: container
+        position: 100
+        config:
+            tabTitle: pim_enrich.form.job_instance.tab.properties.title
+            tabCode: pim-properties
+
+    snowio-csv-product-export-show-content:
+          module: pim/job/product/edit/content
+          parent: snowio-csv-product-export-show-tabs
+          aclResourceId: pim_importexport_export_profile_content_show
+          targetZone: container
+          position: 110
+          config:
+              tabTitle: pim_enrich.form.job_instance.tab.content.title
+              tabCode: pim-job-instance-content
+
+    snowio-csv-product-export-show-history:
+        module: pim/common/tab/history
+        parent: snowio-csv-product-export-show-tabs
+        targetZone: container
+        aclResourceId: pim_importexport_export_profile_history
+        position: 120
+        config:
+            class: Akeneo\Component\Batch\Model\JobInstance
+            title: pim_enrich.form.job_instance.tab.history.title
+            tabCode: pim-history
+
+    snowio-csv-product-export-show-properties-code:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 100
+        targetZone: properties
+        config:
+            fieldCode: code
+            label: pim_enrich.form.job_instance.tab.properties.code.title
+            readOnly: true
+
+    snowio-csv-product-export-show-properties-label:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 110
+        targetZone: properties
+        config:
+            fieldCode: label
+            label: pim_enrich.form.job_instance.tab.properties.label.title
+            readOnly: true
+
+    snowio-csv-product-export-show-properties-decimal-separator:
+        module: pim/job/common/edit/field/decimal-separator
+        parent: snowio-csv-product-export-show-properties
+        position: 130
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.decimalSeparator
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.decimal_separator.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.decimal_separator.help
+
+    snowio-csv-product-export-show-properties-date-format:
+        module: pim/job/product/edit/field/date-format
+        parent: snowio-csv-product-export-show-properties
+        position: 140
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.dateFormat
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.date_format.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.date_format.help
+
+    snowio-csv-product-export-show-properties-delimiter:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 150
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.delimiter
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.delimiter.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
+
+    snowio-csv-product-export-show-properties-enclosure:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 160
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.enclosure
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.enclosure.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
+
+    snowio-csv-product-export-show-properties-with-header:
+        module: pim/job/common/edit/field/switch
+        parent: snowio-csv-product-export-show-properties
+        position: 170
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.withHeader
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.with_header.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+
+    snowio-csv-product-export-show-properties-with-media:
+        module: pim/job/common/edit/field/switch
+        parent: snowio-csv-product-export-show-properties
+        position: 180
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.with_media
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.with_media.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_media.help
+
+    snowio-csv-product-export-show-properties-endpoint:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 190
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.endpoint
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.endpoint.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.endpoint.help
+
+    snowio-csv-product-export-show-properties-secret-key:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 200
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.secretKey
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.secret_key.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.secret_key.help
+
+    snowio-csv-product-export-show-properties-application-id:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 210
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.applicationId
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.application_id.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.application_id.help
+
+    snowio-csv-product-export-show-properties-export-dir:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 220
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.exportDir
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.export_dir.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.export_dir.help
+
+    snowio-csv-product-export-show-properties-rsync-directory:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 230
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncDirectory
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_directory.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_directory.help
+
+    snowio-csv-product-export-show-properties-rsync-user:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 240
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncUser
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_user.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_user.help
+
+    snowio-csv-product-export-show-properties-rsync-host:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 250
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncHost
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_host.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_host.help
+
+    snowio-csv-product-export-show-properties-rsync-options:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-product-export-show-properties
+        position: 240
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncOptions
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_options.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_options.help
+
+    snowio-csv-product-export-show-content-structure:
+        module: pim/job/product/edit/content/structure
+        parent: snowio-csv-product-export-show-content
+        targetZone: structure-filters
+        position: 100
+
+    snowio-csv-product-export-show-label:
+        module: pim/job/common/edit/label
+        parent: snowio-csv-product-export-show
+        targetZone: title
+        position: 100
+
+    snowio-csv-product-export-show-meta:
+        module: pim/job/common/edit/meta
+        parent: snowio-csv-product-export-show
+        targetZone: meta
+        position: 100
+
+    snowio-csv-product-export-show-back-to-grid:
+        module: pim/form/common/back-to-grid
+        parent: snowio-csv-product-export-show
+        targetZone: back
+        aclResourceId: pim_importexport_export_profile_index
+        position: 80
+        config:
+            backUrl: pim_importexport_export_profile_index
+
+    snowio-csv-product-export-show-content-structure-scope:
+        module: pim/job/product/edit/content/structure/scope
+        parent: snowio-csv-product-export-show-content-structure
+        targetZone: filters
+        position: 90
+        config:
+            readOnly: true
+
+    snowio-csv-product-export-show-content-structure-locales:
+        module: pim/job/product/edit/content/structure/locales
+        parent: snowio-csv-product-export-show-content-structure
+        targetZone: filters
+        position: 100
+        config:
+            readOnly: true
+
+    snowio-csv-product-export-show-content-structure-attributes:
+        module: pim/job/product/edit/content/structure/attributes
+        parent: snowio-csv-product-export-show-content-structure
+        targetZone: filters
+        position: 110
+        config:
+            readOnly: true
+
+    snowio-csv-product-export-show-content-data:
+        module: pim/job/product/edit/content/data
+        parent: snowio-csv-product-export-show-content
+        targetZone: data-filters
+        config:
+            filters:
+                -
+                    field: family
+                    view: akeneo-product-family-filter
+                -
+                    field: enabled
+                    view: akeneo-product-enabled-filter
+                -
+                    field: completeness
+                    view: akeneo-product-completeness-filter
+                -
+                    field: updated
+                    view: akeneo-product-updated-filter
+                -
+                    field: categories
+                    view: akeneo-product-category-filter
+
+    snowio-csv-product-export-show-edit:
+        module: pim/common/redirect
+        parent: snowio-csv-product-export-show
+        targetZone: buttons
+        position: 100
+        config:
+            label: pim_enrich.form.job_instance.button.edit.title
+            route: pim_importexport_export_profile_edit
+            identifier:
+                path: code
+                name: code
+
+    snowio-csv-product-export-show-launch:
+        module: pim/job/common/edit/launch
+        parent: snowio-csv-product-export-show
+        targetZone: buttons
+        position: 110
+        config:
+            label: pim_enrich.form.job_instance.button.export.title
+            route: pim_enrich_job_instance_rest_export_launch
+            identifier:
+                path: code
+                name: code

--- a/Resources/config/form_extensions/snowio_product_export_show.yml
+++ b/Resources/config/form_extensions/snowio_product_export_show.yml
@@ -63,7 +63,7 @@ extensions:
         module: pim/job/common/edit/field/decimal-separator
         parent: snowio-csv-product-export-show-properties
         position: 130
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.decimalSeparator
             readOnly: true
@@ -74,7 +74,7 @@ extensions:
         module: pim/job/product/edit/field/date-format
         parent: snowio-csv-product-export-show-properties
         position: 140
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.dateFormat
             readOnly: true
@@ -85,7 +85,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-show-properties
         position: 150
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.delimiter
             readOnly: true
@@ -96,7 +96,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-show-properties
         position: 160
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.enclosure
             readOnly: true
@@ -107,7 +107,7 @@ extensions:
         module: pim/job/common/edit/field/switch
         parent: snowio-csv-product-export-show-properties
         position: 170
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.withHeader
             readOnly: true
@@ -118,7 +118,7 @@ extensions:
         module: pim/job/common/edit/field/switch
         parent: snowio-csv-product-export-show-properties
         position: 180
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.with_media
             readOnly: true
@@ -129,7 +129,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-show-properties
         position: 190
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.endpoint
             readOnly: true
@@ -140,7 +140,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-show-properties
         position: 200
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.secretKey
             readOnly: true
@@ -151,7 +151,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-show-properties
         position: 210
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.applicationId
             readOnly: true
@@ -162,7 +162,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-show-properties
         position: 220
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.exportDir
             readOnly: true
@@ -173,7 +173,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-show-properties
         position: 230
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncDirectory
             readOnly: true
@@ -184,7 +184,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-show-properties
         position: 240
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncUser
             readOnly: true
@@ -195,7 +195,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-show-properties
         position: 250
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncHost
             readOnly: true
@@ -206,7 +206,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-product-export-show-properties
         position: 240
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncOptions
             readOnly: true
@@ -230,15 +230,6 @@ extensions:
         parent: snowio-csv-product-export-show
         targetZone: meta
         position: 100
-
-    snowio-csv-product-export-show-back-to-grid:
-        module: pim/form/common/back-to-grid
-        parent: snowio-csv-product-export-show
-        targetZone: back
-        aclResourceId: pim_importexport_export_profile_index
-        position: 80
-        config:
-            backUrl: pim_importexport_export_profile_index
 
     snowio-csv-product-export-show-content-structure-scope:
         module: pim/job/product/edit/content/structure/scope

--- a/Resources/config/form_extensions/snowio_simple_export_edit.yml
+++ b/Resources/config/form_extensions/snowio_simple_export_edit.yml
@@ -58,7 +58,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-edit-properties
         position: 120
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.delimiter
             readOnly: false
@@ -69,7 +69,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-edit-properties
         position: 130
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.enclosure
             readOnly: false
@@ -80,7 +80,7 @@ extensions:
         module: pim/job/common/edit/field/switch
         parent: snowio-csv-export-edit-properties
         position: 140
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.withHeader
             readOnly: false
@@ -91,7 +91,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-edit-properties
         position: 150
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.endpoint
             readOnly: false
@@ -102,7 +102,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-edit-properties
         position: 160
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.applicationId
             readOnly: false
@@ -113,7 +113,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-edit-properties
         position: 170
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.secretKey
             readOnly: false
@@ -124,7 +124,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-edit-properties
         position: 180
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.exportDir
             readOnly: false
@@ -135,7 +135,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-edit-properties
         position: 190
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncDirectory
             readOnly: false
@@ -146,7 +146,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-edit-properties
         position: 200
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncUser
             readOnly: false
@@ -157,7 +157,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-edit-properties
         position: 210
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncHost
             readOnly: false
@@ -168,7 +168,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-edit-properties
         position: 200
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncOptions
             readOnly: false
@@ -186,15 +186,6 @@ extensions:
         parent: snowio-csv-export-edit
         targetZone: meta
         position: 100
-
-    snowio-csv-export-edit-back-to-grid:
-        module: pim/form/common/back-to-grid
-        parent: snowio-csv-export-edit
-        targetZone: back
-        aclResourceId: pim_importexport_export_profile_index
-        position: 80
-        config:
-            backUrl: pim_importexport_export_profile_index
 
     snowio-csv-export-edit-delete:
         module: pim/job/export/edit/delete

--- a/Resources/config/form_extensions/snowio_simple_export_edit.yml
+++ b/Resources/config/form_extensions/snowio_simple_export_edit.yml
@@ -1,0 +1,237 @@
+extensions:
+    snowio-csv-export-edit:
+        module: pim/form/common/edit-form
+
+    snowio-csv-export-edit-cache-invalidator:
+        module: pim/cache-invalidator
+        parent: snowio-csv-export-edit
+        position: 1000
+
+    snowio-csv-export-edit-tabs:
+        module: pim/form/common/form-tabs
+        parent: snowio-csv-export-edit
+        targetZone: content
+        position: 100
+
+    snowio-csv-export-edit-properties:
+        module: pim/job/common/edit/properties
+        parent: snowio-csv-export-edit-tabs
+        aclResourceId: pim_importexport_export_profile_property_edit
+        targetZone: container
+        position: 100
+        config:
+            tabTitle: pim_enrich.form.job_instance.tab.properties.title
+            tabCode: pim-job-instance-properties
+
+    snowio-csv-export-edit-history:
+        module: pim/common/tab/history
+        parent: snowio-csv-export-edit-tabs
+        targetZone: container
+        aclResourceId: pim_importexport_export_profile_history
+        position: 120
+        config:
+            class: Akeneo\Component\Batch\Model\JobInstance
+            title: pim_enrich.form.job_instance.tab.history.title
+            tabCode: pim-job-instance-history
+
+    snowio-csv-export-edit-properties-code:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 100
+        targetZone: properties
+        config:
+            fieldCode: code
+            label: pim_enrich.form.job_instance.tab.properties.code.title
+            readOnly: true
+
+    snowio-csv-export-edit-properties-label:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 110
+        targetZone: properties
+        config:
+            fieldCode: label
+            label: pim_enrich.form.job_instance.tab.properties.label.title
+            readOnly: false
+
+    snowio-csv-export-edit-properties-delimiter:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 120
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.delimiter
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.delimiter.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
+
+    snowio-csv-export-edit-properties-enclosure:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 130
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.enclosure
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.enclosure.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
+
+    snowio-csv-export-edit-properties-with-header:
+        module: pim/job/common/edit/field/switch
+        parent: snowio-csv-export-edit-properties
+        position: 140
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.withHeader
+            readOnly: false
+            label: pim_enrich.form.job_instance.tab.properties.with_header.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+
+    snowio-csv-export-edit-properties-endpoint:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 150
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.endpoint
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.endpoint.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.endpoint.help
+
+    snowio-csv-export-edit-properties-application-id:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 160
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.applicationId
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.application_id.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.application_id.help
+
+    snowio-csv-export-edit-properties-secret-key:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 170
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.secretKey
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.secret_key.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.secret_key.help
+
+    snowio-csv-export-edit-properties-export-dir:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 180
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.exportDir
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.export_dir.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.export_dir.help
+
+    snowio-csv-export-edit-properties-rsync-directory:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 190
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncDirectory
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_directory.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_directory.help
+
+    snowio-csv-export-edit-properties-rsync-user:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 200
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncUser
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_user.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_user.help
+
+    snowio-csv-export-edit-properties-rsync-host:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 210
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncHost
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_host.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_host.help
+
+    snowio-csv-export-edit-properties-rsync-options:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-edit-properties
+        position: 200
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncOptions
+            readOnly: false
+            label: snowio_connector.form.job_instance.tab.properties.rsync_options.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_options.help
+
+    snowio-csv-export-edit-label:
+        module: pim/job/common/edit/label
+        parent: snowio-csv-export-edit
+        targetZone: title
+        position: 100
+
+    snowio-csv-export-edit-meta:
+        module: pim/job/common/edit/meta
+        parent: snowio-csv-export-edit
+        targetZone: meta
+        position: 100
+
+    snowio-csv-export-edit-back-to-grid:
+        module: pim/form/common/back-to-grid
+        parent: snowio-csv-export-edit
+        targetZone: back
+        aclResourceId: pim_importexport_export_profile_index
+        position: 80
+        config:
+            backUrl: pim_importexport_export_profile_index
+
+    snowio-csv-export-edit-delete:
+        module: pim/job/export/edit/delete
+        parent: snowio-csv-export-edit
+        targetZone: buttons
+        aclResourceId: pim_importexport_export_profile_remove
+        position: 100
+        config:
+            trans:
+                title: confirmation.remove.job_instance
+                content: pim_enrich.confirmation.delete_item
+                success: flash.job_instance.removed
+                failed: error.removing.job_instance
+            redirect: pim_importexport_export_profile_index
+
+    snowio-csv-export-edit-save-buttons:
+        module: pim/form/common/save-buttons
+        parent: snowio-csv-export-edit
+        targetZone: buttons
+        position: 120
+
+    snowio-csv-export-edit-save:
+        module: pim/job-instance-export-edit-form/save
+        parent: snowio-csv-export-edit
+        targetZone: buttons
+        position: 0
+        config:
+            redirectPath: pim_importexport_export_profile_show
+
+    snowio-csv-export-edit-state:
+        module: pim/form/common/state
+        parent: snowio-csv-export-edit
+        targetZone: state
+        position: 900
+        config:
+            entity: pim_enrich.entity.job_instance.title
+
+    snowio-csv-export-edit-validation:
+        module: pim/job/common/edit/validation
+        parent: snowio-csv-export-edit

--- a/Resources/config/form_extensions/snowio_simple_export_show.yml
+++ b/Resources/config/form_extensions/snowio_simple_export_show.yml
@@ -1,0 +1,216 @@
+extensions:
+    snowio-csv-export-show:
+        module: pim/form/common/edit-form
+
+    snowio-csv-export-show-tabs:
+        module: pim/form/common/form-tabs
+        parent: snowio-csv-export-show
+        targetZone: content
+        position: 100
+
+    snowio-csv-export-show-properties:
+        module: pim/job/common/edit/properties
+        parent: snowio-csv-export-show-tabs
+        aclResourceId: pim_importexport_export_profile_property_edit
+        targetZone: container
+        position: 100
+        config:
+            tabTitle: pim_enrich.form.job_instance.tab.properties.title
+            tabCode: pim-job-instance-properties
+
+    snowio-csv-export-show-history:
+        module: pim/common/tab/history
+        parent: snowio-csv-export-show-tabs
+        targetZone: container
+        aclResourceId: pim_importexport_export_profile_history
+        position: 120
+        config:
+            class: Akeneo\Component\Batch\Model\JobInstance
+            title: pim_enrich.form.job_instance.tab.history.title
+            tabCode: pim-job-instance-history
+
+    snowio-csv-export-show-properties-code:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 100
+        targetZone: properties
+        config:
+            fieldCode: code
+            label: pim_enrich.form.job_instance.tab.properties.code.title
+            readOnly: true
+
+    snowio-csv-export-show-properties-label:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 110
+        targetZone: properties
+        config:
+            fieldCode: label
+            label: pim_enrich.form.job_instance.tab.properties.label.title
+            readOnly: true
+
+    snowio-csv-export-show-properties-delimiter:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 120
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.delimiter
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.delimiter.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.delimiter.help
+
+    snowio-csv-export-show-properties-enclosure:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 130
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.enclosure
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.enclosure.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.enclosure.help
+
+    snowio-csv-export-show-properties-with-header:
+        module: pim/job/common/edit/field/switch
+        parent: snowio-csv-export-show-properties
+        position: 140
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.withHeader
+            readOnly: true
+            label: pim_enrich.form.job_instance.tab.properties.with_header.title
+            tooltip: pim_enrich.form.job_instance.tab.properties.with_header.help
+
+    snowio-csv-export-show-properties-endpoint:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 150
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.endpoint
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.endpoint.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.endpoint.help
+
+    snowio-csv-export-show-properties-application-id:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 160
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.applicationId
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.application_id.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.application_id.help
+
+    snowio-csv-export-show-properties-secret-key:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 170
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.secretKey
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.secret_key.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.secret_key.help
+
+    snowio-csv-export-show-properties-export-dir:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 180
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.exportDir
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.export_dir.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.export_dir.help
+
+    snowio-csv-export-show-properties-rsync-directory:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 190
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncDirectory
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_directory.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_directory.help
+
+    snowio-csv-export-show-properties-rsync-user:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 200
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncUser
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_user.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_user.help
+
+    snowio-csv-export-show-properties-rsync-host:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 210
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncHost
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_host.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_host.help
+
+    snowio-csv-export-show-properties-rsync-options:
+        module: pim/job/common/edit/field/text
+        parent: snowio-csv-export-show-properties
+        position: 200
+        targetZone: global-settings
+        config:
+            fieldCode: configuration.rsyncOptions
+            readOnly: true
+            label: snowio_connector.form.job_instance.tab.properties.rsync_options.title
+            tooltip: snowio_connector.form.job_instance.tab.properties.rsync_options.help
+
+    snowio-csv-export-show-label:
+        module: pim/job/common/edit/label
+        parent: snowio-csv-export-show
+        targetZone: title
+        position: 100
+
+    snowio-csv-export-show-meta:
+        module: pim/job/common/edit/meta
+        parent: snowio-csv-export-show
+        targetZone: meta
+        position: 100
+
+    snowio-csv-export-show-back-to-grid:
+        module: pim/form/common/back-to-grid
+        parent: snowio-csv-export-show
+        targetZone: back
+        aclResourceId: pim_importexport_export_profile_index
+        position: 80
+        config:
+            backUrl: pim_importexport_export_profile_index
+
+    snowio-csv-export-show-edit:
+        module: pim/common/redirect
+        parent: snowio-csv-export-show
+        targetZone: buttons
+        position: 100
+        config:
+            label: pim_enrich.form.job_instance.button.edit.title
+            route: pim_importexport_export_profile_edit
+            identifier:
+                path: code
+                name: code
+
+    snowio-csv-export-show-launch:
+        module: pim/job/common/edit/launch
+        parent: snowio-csv-export-show
+        targetZone: buttons
+        position: 110
+        config:
+            label: pim_enrich.form.job_instance.button.export.title
+            route: pim_enrich_job_instance_rest_export_launch
+            identifier:
+                path: code
+                name: code

--- a/Resources/config/form_extensions/snowio_simple_export_show.yml
+++ b/Resources/config/form_extensions/snowio_simple_export_show.yml
@@ -53,7 +53,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-show-properties
         position: 120
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.delimiter
             readOnly: true
@@ -64,7 +64,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-show-properties
         position: 130
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.enclosure
             readOnly: true
@@ -75,7 +75,7 @@ extensions:
         module: pim/job/common/edit/field/switch
         parent: snowio-csv-export-show-properties
         position: 140
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.withHeader
             readOnly: true
@@ -86,7 +86,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-show-properties
         position: 150
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.endpoint
             readOnly: true
@@ -97,7 +97,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-show-properties
         position: 160
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.applicationId
             readOnly: true
@@ -108,7 +108,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-show-properties
         position: 170
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.secretKey
             readOnly: true
@@ -119,7 +119,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-show-properties
         position: 180
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.exportDir
             readOnly: true
@@ -130,7 +130,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-show-properties
         position: 190
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncDirectory
             readOnly: true
@@ -141,7 +141,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-show-properties
         position: 200
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncUser
             readOnly: true
@@ -152,7 +152,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-show-properties
         position: 210
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncHost
             readOnly: true
@@ -163,7 +163,7 @@ extensions:
         module: pim/job/common/edit/field/text
         parent: snowio-csv-export-show-properties
         position: 200
-        targetZone: global-settings
+        targetZone: properties
         config:
             fieldCode: configuration.rsyncOptions
             readOnly: true
@@ -182,19 +182,10 @@ extensions:
         targetZone: meta
         position: 100
 
-    snowio-csv-export-show-back-to-grid:
-        module: pim/form/common/back-to-grid
-        parent: snowio-csv-export-show
-        targetZone: back
-        aclResourceId: pim_importexport_export_profile_index
-        position: 80
-        config:
-            backUrl: pim_importexport_export_profile_index
-
     snowio-csv-export-show-edit:
         module: pim/common/redirect
         parent: snowio-csv-export-show
-        targetZone: buttons
+        targetZone: buttonssnowio-csv-product-export-show-properties-decimal-separator
         position: 100
         config:
             label: pim_enrich.form.job_instance.button.edit.title

--- a/Resources/config/form_extensions/snowio_simple_export_show.yml
+++ b/Resources/config/form_extensions/snowio_simple_export_show.yml
@@ -185,7 +185,7 @@ extensions:
     snowio-csv-export-show-edit:
         module: pim/common/redirect
         parent: snowio-csv-export-show
-        targetZone: buttonssnowio-csv-product-export-show-properties-decimal-separator
+        targetZone: buttons
         position: 100
         config:
             label: pim_enrich.form.job_instance.button.edit.title

--- a/Resources/config/form_parameters.yml
+++ b/Resources/config/form_parameters.yml
@@ -1,0 +1,9 @@
+services:
+    snowio_connector.provider.form.job_instance:
+        class: '%pim_enrich.provider.form.job_instance.class%'
+        arguments:
+            -
+                full_export: snowio-csv-product-export
+                partial_export: snowio-csv-export
+        tags:
+            - { name: pim_enrich.provider.form, priority: 100 }

--- a/Resources/config/job_constraints.yml
+++ b/Resources/config/job_constraints.yml
@@ -1,0 +1,20 @@
+parameters:
+    snowio_connector.job.job_parameters.constraint_collection_provider.product.class: Snowio\Bundle\CsvConnectorBundle\Job\JobParameters\ConstraintCollectionProvider\ProductConstraint
+    snowio_connector.job.job_parameters.constraint_collection_provider.simple.class: Snowio\Bundle\CsvConnectorBundle\Job\JobParameters\ConstraintCollectionProvider\SimpleConstraint
+
+services:
+    # Validation constraints for our JobParameters
+    snowio_connector.job.job_parameters.constraint_collection_provider.full_export:
+          class: '%snowio_connector.job.job_parameters.constraint_collection_provider.product.class%'
+          arguments:
+              - '@pim_connector.job.job_parameters.constraint_collection_provider.simple_csv_export'
+              - ['full_export']
+          tags:
+              - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }
+
+    snowio_connector.job.job_parameters.constraint_collection_provider.partial_export:
+          class: '%snowio_connector.job.job_parameters.constraint_collection_provider.simple.class%'
+          arguments:
+              - ['partial_export']
+          tags:
+              - { name: akeneo_batch.job.job_parameters.constraint_collection_provider }

--- a/Resources/config/job_defaults.yml
+++ b/Resources/config/job_defaults.yml
@@ -1,0 +1,21 @@
+parameters:
+   snowio_connector.job.job_parameters.default_values_provider.product.class: Snowio\Bundle\CsvConnectorBundle\Job\JobParameters\DefaultValuesProvider\ProductDefaultValues
+   snowio_connector.job.job_parameters.default_values_provider.simple.class: Snowio\Bundle\CsvConnectorBundle\Job\JobParameters\DefaultValuesProvider\SimpleDefaultValues
+
+services:
+    snowio_connector.job.job_parameters.default_values_provider.full_export:
+        class: '%snowio_connector.job.job_parameters.default_values_provider.product.class%'
+        arguments:
+            - '@pim_connector.job.job_parameters.default_values_provider.simple_csv_export'
+            - '@pim_catalog.repository.channel'
+            - '@pim_catalog.repository.locale'
+            - ['full_export']
+        tags:
+            - { name: akeneo_batch.job.job_parameters.default_values_provider }
+
+    snowio_connector.job.job_parameters.default_values_provider.partial_export:
+        class: '%snowio_connector.job.job_parameters.default_values_provider.simple.class%'
+        arguments:
+            - ['partial_export']
+        tags:
+            - { name: akeneo_batch.job.job_parameters.default_values_provider }

--- a/Resources/config/jobs.yml
+++ b/Resources/config/jobs.yml
@@ -1,0 +1,46 @@
+parameters:
+    snowio_connector.connector_name.csv: 'Snowio Connector'
+    snowio_connector.job_name.full_export: 'full_export'
+    snowio_connector.job_name.partial_export: 'partial_export'
+
+services:
+    snowio_connector.job.full_export:
+        class: '%pim_connector.job.simple_job.class%'
+        arguments:
+            - '%snowio_connector.job_name.full_export%'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            -
+                - '@snowio_connector.step.csv_product.export'
+                - '@snowio_connector.step.check_threshold.products'
+                - '@snowio_connector.step.csv_product_model.export'
+                - '@snowio_connector.step.csv_category.export'
+                - '@snowio_connector.step.csv_attribute.export'
+                - '@snowio_connector.step.check_threshold.attributes'
+                - '@snowio_connector.step.csv_attribute_option.export'
+                - '@snowio_connector.step.csv_family.export'
+                - '@snowio_connector.step.csv_attribute_group.export'
+                - '@snowio_connector.step.metadata'
+                - '@snowio_connector.step.media_export'
+                - '@snowio_connector.step.archive'
+                - '@snowio_connector.step.post'
+        tags:
+            - { name: akeneo_batch.job, connector: '%snowio_connector.connector_name.csv%', type: '%pim_connector.job.export_type%' }
+
+    snowio_connector.job.partial_export:
+        class: '%pim_connector.job.simple_job.class%'
+        arguments:
+            - '%snowio_connector.job_name.partial_export%'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            -
+                - '@snowio_connector.step.csv_category.export'
+                - '@snowio_connector.step.csv_attribute.export'
+                - '@snowio_connector.step.csv_attribute_option.export'
+                - '@snowio_connector.step.csv_family.export'
+                - '@snowio_connector.step.csv_attribute_group.export'
+                - '@snowio_connector.step.metadata'
+                - '@snowio_connector.step.archive'
+                - '@snowio_connector.step.post'
+        tags:
+            - { name: akeneo_batch.job, connector: '%snowio_connector.connector_name.csv%', type: '%pim_connector.job.export_type%' }

--- a/Resources/config/readers.yml
+++ b/Resources/config/readers.yml
@@ -1,0 +1,7 @@
+parameters:
+  snowio_connector.reader.database.product.class: Snowio\Bundle\CsvConnectorBundle\Reader\Database\ProductModelReader
+
+services:
+  snowio_connector.reader.database.product_model:
+    class: %snowio_connector.reader.database.product.class%
+    parent: pim_connector.reader.database.product_model

--- a/Resources/config/steps.yml
+++ b/Resources/config/steps.yml
@@ -89,7 +89,8 @@ services:
         class: '%pim_connector.step.item_step.class%'
         parent: 'pim_connector.step.csv_product_model.export'
         arguments:
-            index_0: 'variant_group'
+            index_0: 'product_model'
+            index_3: '@snowio_connector.reader.database.product_model'
             index_5: '@snowio_connector.writer.file.csv_product_model'
 
     snowio_connector.step.csv_category.export:

--- a/Resources/config/steps.yml
+++ b/Resources/config/steps.yml
@@ -1,0 +1,128 @@
+parameters:
+    snowio_connector.step.post.class:  Snowio\Bundle\CsvConnectorBundle\Step\PostStep
+    snowio_connector.step.archive.class:  Snowio\Bundle\CsvConnectorBundle\Step\ArchiveStep
+    snowio_connector.step.metadata.class:  Snowio\Bundle\CsvConnectorBundle\Step\MetadataStep
+    guzzlehttp.client.class: GuzzleHttp\Client
+    snowio_connector.step.archive.zip.class: ZipArchive
+    snowio_connector.step.media_export.class: Snowio\Bundle\CsvConnectorBundle\Step\MediaExportStep
+    snowio_connector.step.check_thresholds.class: Snowio\Bundle\CsvConnectorBundle\Step\CheckThresholdsStep
+    snowio_connector.media_export.export_location.class: Snowio\Bundle\CsvConnectorBundle\MediaExport\ExportLocation
+    snowio_connector.media_export.logger.class: Snowio\Bundle\CsvConnectorBundle\MediaExport\Logger
+
+services:
+    guzzlehttp.client:
+        class: '%guzzlehttp.client.class%'
+
+    snowio_connector.step.archive.zip:
+        class: '%snowio_connector.step.archive.zip.class%'
+
+    snowio_connector.step.archive:
+        class: '%snowio_connector.step.archive.class%'
+        arguments:
+            - 'archive'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@snowio_connector.step.archive.zip'
+            - '@snowio_connector.media_export.logger'
+
+    snowio_connector.media_export.export_location:
+        class: '%snowio_connector.media_export.export_location.class%'
+        arguments:
+            - '%media_export_directory%'
+            - '%media_export_host%'
+            - '%media_export_user%'
+
+    snowio_connector.media_export.logger:
+        class: '%snowio_connector.media_export.logger.class%'
+        arguments:
+            - '%kernel.root_dir%/logs/media_export'
+
+    snowio_connector.step.media_export:
+        class: '%snowio_connector.step.media_export.class%'
+        arguments:
+            - 'media_export'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@snowio_connector.media_export.export_location'
+            - '@snowio_connector.media_export.logger'
+
+    snowio_connector.step.post:
+        class: '%snowio_connector.step.post.class%'
+        arguments:
+            - 'post'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@guzzlehttp.client'
+
+    snowio_connector.step.metadata:
+        class: '%snowio_connector.step.metadata.class%'
+        arguments:
+            - 'metadata'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+
+    snowio_connector.step.check_threshold.products:
+        class: '%snowio_connector.step.check_thresholds.class%'
+        arguments:
+            - 'check_thresholds'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '%minimum_products_export%'
+
+    snowio_connector.step.check_threshold.attributes:
+        class: '%snowio_connector.step.check_thresholds.class%'
+        arguments:
+            - 'check_thresholds'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '%minimum_attributes_export%'
+
+    # Overwrite service definition to set step name (arg 0) and writer
+    snowio_connector.step.csv_product.export:
+        class: '%pim_connector.step.item_step.class%'
+        parent: 'pim_connector.step.csv_product.export'
+        arguments:
+            index_0: 'product'
+            index_5: '@snowio_connector.writer.file.csv_product'
+
+    snowio_connector.step.csv_product_model.export:
+        class: '%pim_connector.step.item_step.class%'
+        parent: 'pim_connector.step.csv_product_model.export'
+        arguments:
+            index_0: 'variant_group'
+            index_5: '@snowio_connector.writer.file.csv_product_model'
+
+    snowio_connector.step.csv_category.export:
+        class: '%pim_connector.step.item_step.class%'
+        parent: 'pim_connector.step.csv_category.export'
+        arguments:
+            index_0: 'category'
+            index_5: '@snowio_connector.writer.file.csv_category'
+
+    snowio_connector.step.csv_attribute.export:
+        class: '%pim_connector.step.item_step.class%'
+        parent: 'pim_connector.step.csv_attribute.export'
+        arguments:
+            index_0: 'attribute'
+            index_5: '@snowio_connector.writer.file.csv_attribute'
+
+    snowio_connector.step.csv_attribute_option.export:
+        class: '%pim_connector.step.item_step.class%'
+        parent: 'pim_connector.step.csv_attribute_option.export'
+        arguments:
+            index_0: 'attribute_option'
+            index_5: '@snowio_connector.writer.file.csv_attribute_option'
+
+    snowio_connector.step.csv_family.export:
+        class: '%pim_connector.step.item_step.class%'
+        parent: 'pim_connector.step.csv_family.export'
+        arguments:
+            index_0: 'family'
+            index_5: '@snowio_connector.writer.file.csv_family'
+
+    snowio_connector.step.csv_attribute_group.export:
+        class: '%pim_connector.step.item_step.class%'
+        parent: 'pim_connector.step.csv_attribute_group_export.export'
+        arguments:
+            index_0: 'attribute_group'
+            index_5: '@snowio_connector.writer.file.csv_attribute_group'

--- a/Resources/config/writers.yml
+++ b/Resources/config/writers.yml
@@ -1,0 +1,33 @@
+parameters:
+  snowio_connector.writer.file.csv_product.class: Snowio\Bundle\CsvConnectorBundle\Writer\File\Csv\ProductWriter
+  snowio_connector.writer.file.csv_product_model.class: Snowio\Bundle\CsvConnectorBundle\Writer\File\Csv\ProductModelWriter
+  snowio_connector.writer.file.csv_simple.class: Snowio\Bundle\CsvConnectorBundle\Writer\File\Csv\SimpleWriter
+
+services:
+  snowio_connector.writer.file.csv_product:
+    class: %snowio_connector.writer.file.csv_product.class%
+    parent: pim_connector.writer.file.csv_product
+
+  snowio_connector.writer.file.csv_product_model:
+    class: %snowio_connector.writer.file.csv_product_model.class%
+    parent: pim_connector.writer.file.csv_product_model
+
+  snowio_connector.writer.file.csv_category:
+    class: %snowio_connector.writer.file.csv_simple.class%
+    parent: pim_connector.writer.file.csv_category
+
+  snowio_connector.writer.file.csv_attribute:
+    class: %snowio_connector.writer.file.csv_simple.class%
+    parent: pim_connector.writer.file.csv_attribute
+
+  snowio_connector.writer.file.csv_attribute_option:
+    class: %snowio_connector.writer.file.csv_simple.class%
+    parent: pim_connector.writer.file.csv_attribute_option
+
+  snowio_connector.writer.file.csv_family:
+    class: %snowio_connector.writer.file.csv_simple.class%
+    parent: pim_connector.writer.file.csv_family
+
+  snowio_connector.writer.file.csv_attribute_group:
+    class: %snowio_connector.writer.file.csv_simple.class%
+    parent: pim_connector.writer.file.csv_attribute_group

--- a/Resources/translations/jsmessages.en.yml
+++ b/Resources/translations/jsmessages.en.yml
@@ -1,0 +1,34 @@
+job_execution:
+  summary:
+    zip_location: Zip File Location
+    url: Send Zip to Endpoint
+    metadata_location: Metadata file
+    response_code: Response Code
+    response_body: Response Body
+
+snowio_connector.form.job_instance.tab.properties:
+  endpoint:
+    title: Endpoint Url
+    help: The URL where to make the request after file generation.
+  application_id:
+    title: Application Id
+    help: The Application ID provided by Snow.io
+  secret_key:
+    title: Secret Key
+    help: The Secret Key provided by Snow.io
+  export_dir:
+    title: Export Directory
+    help: The directory to store CSV and ZIP files.
+  rsync_directory:
+    title: Rsync Directory
+    help: The directory to rsync images to
+  rsync_user:
+    title: Rsync User
+    help: The user for the media rsync step.
+  rsync_host:
+    title: Rsync Host
+    help: The host for the media rsync step.
+  rsync_options:
+    title: Rsync Options
+    help: Any other rsync options required
+

--- a/Resources/translations/messages.en.yml
+++ b/Resources/translations/messages.en.yml
@@ -1,0 +1,37 @@
+batch_jobs:
+    partial_export:
+        label: "Partial Export (categories, attributes, attribute options, families and attribute groups)"
+        category.label:  "Category Export Step"
+        attribute.label: "Attribute Export Step"
+        attribute_option.label: "Attribute Option Export Step"
+        family.label: "Family Export Step"
+        attribute_group.label: "Attribute Group Export Step"
+        archive.label: "Archive Step"
+        metadata.label: "Metadata Step"
+        post.label: "Post Step"
+        media_export.label: "Media Export Step"
+    full_export:
+        label: "Full Export (products, variant groups, categories, attributes, attribute options, families and attribute groups)"
+        product.label: "Product Export Step"
+        variant_group.label: "Variant Group Export Step"
+        category.label:  "Category Export Step"
+        attribute.label: "Attribute Export Step"
+        attribute_option.label: "Attribute Option Export Step"
+        family.label: "Family Export Step"
+        attribute_group.label: "Attribute Group Export Step"
+        archive.label: "Archive Step"
+        metadata.label: "Metadata Step"
+        post.label: "Post Step"
+        media_export.label: "Media Export Step"
+        check_thresholds.label: "Check Thresholds Step"
+
+job_execution:
+    summary:
+        endpoint: Endpoint
+        response_code: Response code
+        response_body: Body
+        zip_location: Zip file
+        metadata_location: Metadata file
+        export_location: Export location
+        log_file: Log file
+        minimum_threshold: Minimum threshold

--- a/Resources/translations/messages.en.yml
+++ b/Resources/translations/messages.en.yml
@@ -11,9 +11,9 @@ batch_jobs:
         post.label: "Post Step"
         media_export.label: "Media Export Step"
     full_export:
-        label: "Full Export (products, variant groups, categories, attributes, attribute options, families and attribute groups)"
+        label: "Full Export (products, product models, categories, attributes, attribute options, families and attribute groups)"
         product.label: "Product Export Step"
-        variant_group.label: "Variant Group Export Step"
+        product_model.label: "Product model Export Step"
         category.label:  "Category Export Step"
         attribute.label: "Attribute Export Step"
         attribute_option.label: "Attribute Option Export Step"

--- a/SnowioCsvConnectorBundle.php
+++ b/SnowioCsvConnectorBundle.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Pim\Bundle\EnrichBundle\DependencyInjection\Reference\ReferenceFactory;
+
+/**
+ * Class SnowioCsvConnectorBundle
+ * @package Snowio\Bundle\SnowioCsvConnectorBundle
+ * @author Nei Santos <ns@amp.co>
+ *
+ * This Bundle is used to create new csv export jobs that:
+ * 1) Generate CSV files, using Akeneo's Csv Connector functionality
+ * 2) Posts product data to a Snow.io using Guzzle
+ */
+class SnowioCsvConnectorBundle extends Bundle
+{
+    /** Increment the version number if exported data has BC break changes. */
+    const VERSION = 2;
+}

--- a/Step/ArchiveStep.php
+++ b/Step/ArchiveStep.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Step;
+
+use Akeneo\Component\Batch\Step\AbstractStep;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use Snowio\Bundle\CsvConnectorBundle\MediaExport;
+use \ZipArchive;
+
+class ArchiveStep extends AbstractStep
+{
+    const ZIP_FILE_NAME = 'export.zip';
+
+    /** @var ZipArchive */
+    protected $zip;
+
+    /** @var \Snowio\Bundle\CsvConnectorBundle\MediaExport\Logger */
+    private $mediaExportLogger;
+
+    /**
+     * @param string                   $name
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param JobRepositoryInterface   $jobRepository
+     * @param ZipArchive               $zip
+     * @param string                   $logDir
+     */
+    public function __construct(
+        $name,
+        EventDispatcherInterface $eventDispatcher,
+        JobRepositoryInterface $jobRepository,
+        ZipArchive $zip,
+        MediaExport\Logger $mediaExportLogger
+    ) {
+        $this->name = $name;
+        $this->jobRepository = $jobRepository;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->zip = $zip;
+        $this->mediaExportLogger = $mediaExportLogger;
+    }
+
+    /**
+     * Archive will Zip the csv files on the specified directory
+     * and the metada.json file.
+     *
+     * @param StepExecution    $stepExecution
+     */
+    protected function doExecute(StepExecution $stepExecution)
+    {
+        $jobParameters = $stepExecution->getJobParameters();
+
+        $location = rtrim($jobParameters->get('exportDir'), '/') . DIRECTORY_SEPARATOR . self::ZIP_FILE_NAME;
+
+        $opened = $this->zip->open($location, ZipArchive::CREATE);
+
+        if ($opened !== true) {
+            $stepExecution->addFailureException(new \RuntimeException('Failed to open zip, reason code:' . $opened));
+        } else {
+            $this->zip->addFile(
+                $this->mediaExportLogger->getLogFileNameForJob($stepExecution->getJobExecution()->getId()),
+                '/media_export.log'
+            );
+
+            $success = $this->zip->addPattern(
+                '/(?:\w+\.csv|metadata.json)/',
+                $jobParameters->get('exportDir'),
+                ['add_path' => '/', 'remove_all_path' => true]
+            );
+
+            if (!$success) {
+                $stepExecution->addFailureException(new \RuntimeException('Failed to add files to zip.'));
+                return;
+            }
+
+            $this->zip->close();
+
+            $stepExecution->addSummaryInfo('zip_location', $location);
+        }
+    }
+}

--- a/Step/CheckThresholdsStep.php
+++ b/Step/CheckThresholdsStep.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Step;
+
+use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\AbstractStep;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Use this class to check export threshold has been met in previous step
+ * Create a service, inject the relevant threshold, and configure the job so this comes after the step you want to check
+ */
+class CheckThresholdsStep extends AbstractStep
+{
+    /** @var int */
+    private $minimumExportThreshold;
+
+    /**
+     * CheckThresholdsStep constructor.
+     * @param string $name
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param JobRepositoryInterface $jobRepository
+     * @param $minimumExportThreshold
+     */
+    public function __construct(
+        $name,
+        EventDispatcherInterface $eventDispatcher,
+        JobRepositoryInterface $jobRepository,
+        $minimumExportThreshold = 0
+    ) {
+        parent::__construct($name, $eventDispatcher, $jobRepository);
+        $this->minimumExportThreshold = (int)$minimumExportThreshold;
+    }
+
+    /**
+     * Extension point for subclasses to execute business logic. Subclasses should set the {@link ExitStatus} on the
+     * {@link StepExecution} before returning.
+     *
+     * Do not catch exception here. It will be correctly handled by the execute() method.
+     *
+     * @param StepExecution $stepExecution the current step context
+     *
+     * @throws \Exception
+     */
+    protected function doExecute(StepExecution $stepExecution)
+    {
+        $previousStepExecution = $this->getPreviousStepExecution($stepExecution);
+
+        $stepExecution->addSummaryInfo(
+            'minimum_threshold',
+            sprintf('%s (%s)', $this->minimumExportThreshold, $previousStepExecution->getStepName())
+        );
+
+        if ($this->minimumExportThreshold > 0 && !$this->doesExportCountMeetThreshold($previousStepExecution)) {
+            throw new \Exception(
+                sprintf(
+                    'Error - attempted to export less than the minimum threshold (step: %s/threshold: %s).',
+                    $previousStepExecution->getStepName(),
+                    $this->minimumExportThreshold
+                )
+            );
+        }
+    }
+
+    /**
+     * @param StepExecution $stepExecution
+     * @return bool
+     * @author James Pollard <jp@amp.co>
+     */
+    private function doesExportCountMeetThreshold(StepExecution $stepExecution)
+    {
+        return $stepExecution->getSummaryInfo('read') >= $this->minimumExportThreshold;
+    }
+
+    /**
+     * @param StepExecution $stepExecution
+     * @return StepExecution
+     * @throws \Exception
+     * @author James Pollard <jp@amp.co>
+     */
+    private function getPreviousStepExecution(StepExecution $stepExecution)
+    {
+        $stepExecutions = $stepExecution->getJobExecution()->getStepExecutions()->toArray();
+        // set array pointer to last element i.e. the current execution
+        end($stepExecutions);
+        $previousStepExecution = prev($stepExecutions);
+
+        if (!($previousStepExecution instanceof StepExecution)) {
+            throw new \Exception('Error during threshold check step - previous execution step was not found.');
+        }
+
+        return $previousStepExecution;
+    }
+}

--- a/Step/MediaExportStep.php
+++ b/Step/MediaExportStep.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Step;
+
+use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Step\AbstractStep;
+use Akeneo\Component\FileStorage\Exception\FileTransferException;
+use Snowio\Bundle\CsvConnectorBundle\MediaExport\ExportLocation;
+use Snowio\Bundle\CsvConnectorBundle\MediaExport\Logger;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
+
+/**
+ * This class rsyncs media files to a configurable location and logs some info a separate log file
+ * Forcing reconnect to MySQL was looked into as part of this, which is not necessary:
+ * @see \Akeneo\Bundle\BatchBundle\Job\DoctrineJobRepository::updateStepExecution
+ */
+class MediaExportStep extends AbstractStep
+{
+    /** @var ExportLocation */
+    protected $exportLocation;
+
+    /** @var Logger */
+    private $logger;
+
+    /**
+     * MediaExportStep constructor.
+     * @param string $name
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param JobRepositoryInterface $jobRepository
+     * @param ExportLocation $exportLocation
+     * @param Logger $logger
+     */
+    public function __construct(
+        $name,
+        EventDispatcherInterface $eventDispatcher,
+        JobRepositoryInterface $jobRepository,
+        ExportLocation $exportLocation,
+        Logger $logger
+    ) {
+        parent::__construct($name, $eventDispatcher, $jobRepository);
+        $this->exportLocation = $exportLocation;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Extension point for subclasses to execute business logic. Subclasses should set the {@link ExitStatus} on the
+     * {@link StepExecution} before returning.
+     *
+     * Do not catch exception here. It will be correctly handled by the execute() method.
+     *
+     * @param StepExecution $stepExecution the current step context
+     *
+     * @throws \Exception
+     */
+    protected function doExecute(StepExecution $stepExecution)
+    {
+        try {
+            $currentExportDir = rtrim($stepExecution->getJobParameters()->get('exportDir'), '/');
+
+            $this->exportLocation->setUser($stepExecution->getJobParameters()->get('rsyncUser'));
+            $this->exportLocation->setHost($stepExecution->getJobParameters()->get('rsyncHost'));
+            $this->exportLocation->setDirectory($stepExecution->getJobParameters()->get('rsyncDirectory'));
+
+            $newExportDir = rtrim($this->exportLocation->toString(), '/');
+
+            $stepExecution->addSummaryInfo('export_location', $newExportDir);
+
+            $stepExecution->addSummaryInfo(
+                'log_file',
+                $this->logger->getLogFileNameForJob($stepExecution->getJobExecution()->getId())
+            );
+
+            $output = $this->syncMedia($currentExportDir, $newExportDir, $stepExecution->getJobParameters()->get('rsyncOptions'));
+
+            $this->writeLog(
+                $this->getModifiedOutputForLog($output, $stepExecution),
+                $stepExecution->getJobExecution()
+            );
+
+        } catch (FileTransferException $e) {
+            $this->writeLog(
+                ['Error - something went wrong during rsync.', $e->getMessage()],
+                $stepExecution->getJobExecution()
+            );
+
+            //Do not rethrow the exception we want execution to proceed
+        } catch(\Exception $e) {
+            $this->writeLog(
+                ['Error - something went wrong during media export.', $e->getMessage()],
+                $stepExecution->getJobExecution()
+            );
+            throw $e;
+        }
+    }
+
+    /**
+     * @param $currentExportDir
+     * @param $newExportDir
+     * @param $options
+     * @return array
+     * @throws FileTransferException
+     * @author James Pollard <jp@amp.co>
+     */
+    protected function syncMedia($currentExportDir, $newExportDir, $options = '')
+    {
+        /**
+         * append files to the current export dir so that we do not unnecessarily
+         * copy over the export csv files
+         */
+        exec("rsync -aK $options $currentExportDir/files/ $newExportDir/", $output, $status);
+
+        if ($status !== 0) {
+            throw new FileTransferException('Error - rsync failure during media export.' . implode(" : ", $output));
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param array $content
+     * @author James Pollard <jp@amp.co>
+     */
+    protected function writeLog(array $content, JobExecution $job)
+    {
+        $this->logger->writeLog($content, $job->getId());
+    }
+
+    /**
+     * @param array $output
+     * @param StepExecution $stepExecution
+     * @return array
+     * @author James Pollard <jp@amp.co>
+     */
+    protected function getModifiedOutputForLog(array $output, StepExecution $stepExecution)
+    {
+        $jobParameters = $stepExecution->getJobParameters();
+        $jobExecution = $stepExecution->getJobExecution();
+
+        array_unshift(
+            $output,
+            '------------------------------',
+            sprintf('Export Profile: %s (%s)', $jobExecution->getLabel(), $jobParameters->get('applicationId')),
+            sprintf('Execution ID: %s', $jobExecution->getId()),
+            date('d/m/Y H:i:s')
+        );
+
+        return $output;
+    }
+}

--- a/Step/MetadataStep.php
+++ b/Step/MetadataStep.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Step;
+
+use Akeneo\Component\Batch\Step\AbstractStep;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Snowio\Bundle\CsvConnectorBundle\SnowioCsvConnectorBundle;
+
+class MetadataStep extends AbstractStep
+{
+    /**
+     * Create json file with metadata information
+     *
+     * @param StepExecution $stepExecution
+     */
+    protected function doExecute(StepExecution $stepExecution)
+    {
+        $jobParameters = $stepExecution->getJobParameters();
+
+        $location = rtrim($jobParameters->get('exportDir'), '/') . DIRECTORY_SEPARATOR . 'metadata.json';
+
+        $content = $this->generateContent($stepExecution, $jobParameters);
+
+        if (false === file_put_contents($location, $content)) {
+            $stepExecution->addFailureException(
+                new \RuntimeException('Cannot create metadata file.')
+            );
+        }
+
+        $stepExecution->addSummaryInfo('metadata_location', $location);
+    }
+
+    /**
+     * Create json file with metadata
+     *
+     * @param StepExecution $stepExecution
+     * @param JobParameters $jobParameters
+     *
+     * @return String Json
+     */
+    protected function generateContent($stepExecution, $jobParameters)
+    {
+        $content = [
+            'bundleVersion'     => SnowioCsvConnectorBundle::VERSION,
+            'jobCode'           => $stepExecution->getJobExecution()->getJobInstance()->getJobName(),
+            'date'              => gmdate('Y-m-d H:i:s'),
+            'delimiter'         => $jobParameters->get('delimiter'),
+            'enclosure'         => $jobParameters->get('enclosure'),
+            'withHeader'        => $jobParameters->get('withHeader')
+        ];
+
+        if ($jobParameters->has('filters')) {
+            $content['filters'] = $jobParameters->get('filters');
+        }
+
+        if ($jobParameters->has('decimalSeparator')) {
+            $content['decimalSeparator'] = $jobParameters->get('decimalSeparator');
+        }
+
+        if ($jobParameters->has('dateFormat')) {
+            $content['dateFormat'] = $jobParameters->get('dateFormat');
+        }
+
+        if ($jobParameters->has('with_media')) {
+            $content['with_media'] = $jobParameters->get('with_media');
+        }
+
+        return json_encode($content);
+    }
+}

--- a/Step/PostStep.php
+++ b/Step/PostStep.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Step;
+
+use Akeneo\Component\Batch\Step\AbstractStep;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use GuzzleHttp\Client;
+
+class PostStep extends AbstractStep
+{
+    /** @var ClientInterface */
+    protected $guzzle;
+
+    /**
+     * @param string                   $name
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param JobRepositoryInterface   $jobRepository
+     * @param Client                   $guzzle
+     */
+    public function __construct(
+        $name,
+        EventDispatcherInterface $eventDispatcher,
+        JobRepositoryInterface $jobRepository,
+        Client $guzzle
+    ) {
+        $this->name = $name;
+        $this->jobRepository = $jobRepository;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->guzzle = $guzzle;
+    }
+
+    /**
+     * Post Step will send the zip file generated on preview step
+     * to Snow.io
+     *
+     * @author Nei Rauni <nr@amp.co>
+     * @param StepExecution $stepExecution
+     */
+    protected function doExecute(StepExecution $stepExecution)
+    {
+        $jobParameters = $stepExecution->getJobParameters();
+        $endpoint = $jobParameters->get('endpoint') . $jobParameters->get('applicationId');
+
+        $stepExecution->addSummaryInfo('endpoint', $endpoint);
+
+        $zipFile = rtrim($jobParameters->get('exportDir'), '/') . DIRECTORY_SEPARATOR . ArchiveStep::ZIP_FILE_NAME;
+
+        if (!file_exists($zipFile)) {
+            $stepExecution->addFailureException(
+                new \RuntimeException('Failed to open file '.$zipFile.' to send to snow.io')
+            );
+        }
+
+        if (($resource = fopen($zipFile, 'r')) === false) {
+            $stepExecution->addFailureException(
+                new \RuntimeException('Failed to open file '.$zipFile.' to send to snow.io')
+            );
+        }
+
+        $response = $this->guzzle->request(
+            'POST',
+            $endpoint,
+            [
+                'body'      => $resource,
+                'headers'   => [
+                    'Content-Type'          => 'application/zip',
+                    'Authorization'         => $jobParameters->get('secretKey'),
+                ],
+            ]
+        );
+
+        if ($response->getStatusCode() !== 204) {
+            $stepExecution->addFailureException(new \Exception('Failed to POST CSV file: ' . $response->getBody()));
+        }
+
+        $stepExecution->addSummaryInfo('response_code', $response->getStatusCode());
+        $stepExecution->addSummaryInfo('response_body', $response->getBody()->getContents());
+    }
+}

--- a/Writer/File/Csv/ProductModelWriter.php
+++ b/Writer/File/Csv/ProductModelWriter.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Writer\File\Csv;
+
+use Pim\Component\Connector\Writer\File\Csv\VariantGroupWriter as BaseVariantGroupWriter;
+
+class ProductModelWriter extends BaseVariantGroupWriter
+{
+    use WriterOverriderTrait;
+}

--- a/Writer/File/Csv/ProductModelWriter.php
+++ b/Writer/File/Csv/ProductModelWriter.php
@@ -2,9 +2,9 @@
 
 namespace Snowio\Bundle\CsvConnectorBundle\Writer\File\Csv;
 
-use Pim\Component\Connector\Writer\File\Csv\VariantGroupWriter as BaseVariantGroupWriter;
+use Pim\Component\Connector\Writer\File\Csv\ProductModelWriter as BaseProductModelWriter;
 
-class ProductModelWriter extends BaseVariantGroupWriter
+class ProductModelWriter extends BaseProductModelWriter
 {
     use WriterOverriderTrait;
 }

--- a/Writer/File/Csv/ProductWriter.php
+++ b/Writer/File/Csv/ProductWriter.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Writer\File\Csv;
+
+use Pim\Component\Connector\Writer\File\Csv\ProductWriter as BaseProductWriter;
+
+class ProductWriter extends BaseProductWriter
+{
+    use WriterOverriderTrait;
+}

--- a/Writer/File/Csv/SimpleWriter.php
+++ b/Writer/File/Csv/SimpleWriter.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Writer\File\Csv;
+
+use Pim\Component\Connector\Writer\File\Csv\Writer;
+
+class SimpleWriter extends Writer
+{
+    use WriterOverriderTrait;
+}

--- a/Writer/File/Csv/WriterOverriderTrait.php
+++ b/Writer/File/Csv/WriterOverriderTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Snowio\Bundle\CsvConnectorBundle\Writer\File\Csv;
+
+use Akeneo\Component\Batch\Job\JobInterface;
+
+trait WriterOverriderTrait
+{
+    /**
+     * We overwrite the getPath to use step name as filename
+     * @author Nei Santos <ns@amp.co>
+     * @return string
+     */
+    public function getPath(array $placeholders = [])
+    {
+        $parameters = $this->stepExecution->getJobParameters();
+
+        $filePath = implode(
+            '',
+            [
+                rtrim($parameters->get('exportDir'), '/'),
+                DIRECTORY_SEPARATOR,
+                $this->sanitize($this->stepExecution->getStepName()),
+                ".csv"
+            ]
+        );
+
+        return $filePath;
+    }
+
+    /**
+     * Export medias from the working directory to the output expected directory.
+     *
+     * Basically, we first remove the content of /path/where/my/user/expects/the/export/files/.
+     * (This path can exist of an export was launched previously)
+     *
+     * Then we copy /path/of/the/working/directory/files/ to /path/where/my/user/expects/the/export/files/.
+     */
+    protected function exportMedias()
+    {
+        $outputDirectory = dirname($this->getPath());
+        $workingDirectory = $this->stepExecution->getJobExecution()->getExecutionContext()
+            ->get(JobInterface::WORKING_DIRECTORY_PARAMETER);
+
+        $outputFilesDirectory = $outputDirectory . DIRECTORY_SEPARATOR . 'files';
+        $workingFilesDirectory = $workingDirectory . 'files';
+
+        /*
+        if ($this->localFs->exists($outputFilesDirectory)) {
+            $this->localFs->remove($outputFilesDirectory);
+        }*/
+
+        if ($this->localFs->exists($workingFilesDirectory)) {
+            $this->localFs->mirror($workingFilesDirectory, $outputFilesDirectory);
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,38 @@
+{
+  "name": "snowio/akeneo-bundle",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Cristian Quiroz",
+      "email": "cq@amp.co"
+    }, {
+      "name": "Nei Santos",
+      "email": "ns@amp.co"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/akeneo/pim-community-dev.git",
+      "branch": "master"
+    }
+  ],
+  "require": {
+    "akeneo/pim-community-dev": "^2.2.*",
+    "guzzlehttp/guzzle": "^6.1",
+    "symfony/config": "^2.7.2",
+    "symfony/dependency-injection": "^2.7.2",
+    "symfony/http-kernel": "^2.7.2",
+    "phpspec/phpspec": "^3.2"
+  },
+  "scripts": {
+    "test": "php vendor/bin/phpspec run --format=dot -c phpspec.yml",
+    "cs": "phpcs --standard=PSR2 -n ./ --ignore=vendor --report=summary"
+  },
+  "autoload": {
+    "psr-4": {
+      "Snowio\\Bundle\\CsvConnectorBundle\\": ""
+    }
+  },
+  "minimum-stability": "dev"
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   ],
   "require": {
-    "akeneo/pim-community-dev": "^2.2.*",
+    "akeneo/pim-community-dev": "2.*.*",
     "guzzlehttp/guzzle": "^6.1",
     "symfony/config": "^2.7.2",
     "symfony/dependency-injection": "^2.7.2",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "snowio/akeneo-bundle",
+  "name": "snowio/akeneo2-snow-bundle",
   "license": "MIT",
   "authors": [
     {
@@ -8,6 +8,9 @@
     }, {
       "name": "Nei Santos",
       "email": "ns@amp.co"
+    }, {
+      "name": "Liam Toohey",
+      "email": "lt@amp.co"
     }
   ],
   "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
   "require": {
     "akeneo/pim-community-dev": "2.*.*",
     "guzzlehttp/guzzle": "^6.1",
-    "symfony/config": "^2.7.2",
-    "symfony/dependency-injection": "^2.7.2",
-    "symfony/http-kernel": "^2.7.2",
+    "symfony/config": "^3.4.0",
+    "symfony/dependency-injection": "^3.4.0",
+    "symfony/http-kernel": "^3.4.0",
     "phpspec/phpspec": "^3.2"
   },
   "scripts": {

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,5 +1,0 @@
-suites:
-    SnowioCsvConnectorBundle:
-        namespace: Snowio\Bundle\CsvConnectorBundle
-        psr4_prefix: Snowio\Bundle\CsvConnectorBundle
-        src_path: .

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,0 +1,5 @@
+suites:
+    SnowioCsvConnectorBundle:
+        namespace: Snowio\Bundle\CsvConnectorBundle
+        psr4_prefix: Snowio\Bundle\CsvConnectorBundle
+        src_path: .

--- a/spec/Job/JobParameters/ConstraintCollectionProvider/ProductConstraintSpec.php
+++ b/spec/Job/JobParameters/ConstraintCollectionProvider/ProductConstraintSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace spec\Snowio\Bundle\CsvConnectorBundle\Job\JobParameters\ConstraintCollectionProvider;
+
+use PhpSpec\ObjectBehavior;
+use Akeneo\Component\Batch\Job\JobParameters\ConstraintCollectionProviderInterface;
+use Symfony\Component\Validator\Constraints\Collection;
+use Akeneo\Component\Batch\Job\JobInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class ProductConstraintSpec extends ObjectBehavior
+{
+    public function let(
+        ConstraintCollectionProviderInterface $provider
+    ) {
+        $this->beConstructedWith(
+            $provider,
+            ['test11','test22']
+        );
+    }
+
+    // @codingStandardsIgnoreLine
+    public function it_is_a_default_values()
+    {
+        $this->shouldImplement('Akeneo\Component\Batch\Job\JobParameters\ConstraintCollectionProviderInterface');
+    }
+
+    // @codingStandardsIgnoreLine
+    public function it_supports_a_job(JobInterface $job)
+    {
+        $job->getName()->willReturn('test11');
+        $this->supports($job)->shouldReturn(true);
+    }
+
+    // @codingStandardsIgnoreLine
+    public function it_provides_constraints_collection(
+        $provider,
+        Collection $decoratedCollection
+    ) {
+        $provider->getConstraintCollection()->willReturn($decoratedCollection);
+        $collection = $this->getConstraintCollection();
+        $collection->shouldReturnAnInstanceOf('Symfony\Component\Validator\Constraints\Collection');
+        $fields = $collection->fields;
+
+        $fields->shouldHaveCount(8);
+        $fields->shouldHaveKey('decimalSeparator');
+        $fields->shouldHaveKey('dateFormat');
+        $fields->shouldHaveKey('with_media');
+        $fields->shouldHaveKey('endpoint');
+        $fields->shouldHaveKey('applicationId');
+        $fields->shouldHaveKey('secretKey');
+        $fields->shouldHaveKey('exportDir');
+    }
+}

--- a/spec/Job/JobParameters/DefaultValuesProvider/ProductDefaultValuesSpec.php
+++ b/spec/Job/JobParameters/DefaultValuesProvider/ProductDefaultValuesSpec.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace spec\Snowio\Bundle\CsvConnectorBundle\Job\JobParameters\DefaultValuesProvider;
+
+use PhpSpec\ObjectBehavior;
+use Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
+use Pim\Component\Catalog\Repository\ChannelRepositoryInterface;
+use Pim\Component\Catalog\Repository\LocaleRepositoryInterface;
+use Pim\Component\Catalog\Model\LocaleInterface;
+use Pim\Component\Catalog\Model\ChannelInterface;
+use Akeneo\Component\Batch\Job\JobInterface;
+
+class ProductDefaultValuesSpec extends ObjectBehavior
+{
+    public function let(
+        DefaultValuesProviderInterface $decoratedProvider,
+        ChannelRepositoryInterface $channelRepository,
+        LocaleRepositoryInterface $localeRepository
+    ) {
+        $this->beConstructedWith($decoratedProvider, $channelRepository, $localeRepository, ['my_supported_job_name']);
+    }
+
+    // @codingStandardsIgnoreLine
+    function it_is_a_default_values()
+    {
+        $this->shouldImplement('Akeneo\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface');
+    }
+
+    // @codingStandardsIgnoreLine
+    function it_supports_a_job(JobInterface $job)
+    {
+        $job->getName()->willReturn('my_supported_job_name');
+        $this->supports($job)->shouldReturn(true);
+    }
+
+    // @codingStandardsIgnoreLine
+    function it_provides_default_values(
+        $decoratedProvider,
+        ChannelRepositoryInterface $channelRepository,
+        LocaleRepositoryInterface $localeRepository,
+        LocaleInterface $locale,
+        ChannelInterface $channel
+    ) {
+        $channel->getCode()->willReturn('channel_code');
+        $channelRepository->getFullChannels()->willReturn([$channel]);
+
+        $locale->getCode()->willReturn('locale_code');
+        $localeRepository->getActivatedLocaleCodes()->willReturn([$locale]);
+
+        $decoratedProvider->getDefaultValues()->willReturn(['decoratedParam' => true]);
+        $this->getDefaultValues()->shouldReturnWellFormedDefaultValues();
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'returnWellFormedDefaultValues' => function ($parameters) {
+                return true === $parameters['decoratedParam'] &&
+                    '.' === $parameters['decimalSeparator'] &&
+                    '' === $parameters['endpoint'] &&
+                    '' === $parameters['secretKey'] &&
+                    '' === $parameters['applicationId'] &&
+                    '' === $parameters['exportDir'];
+            }
+        ];
+    }
+}

--- a/spec/Step/ArchiveStepSpec.php
+++ b/spec/Step/ArchiveStepSpec.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace spec\Snowio\Bundle\CsvConnectorBundle\Step;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Job\BatchStatus;
+use Akeneo\Component\Batch\Job\ExitStatus;
+use Akeneo\Component\Batch\Event\EventInterface;
+use Akeneo\Component\Batch\Job\JobParameters;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use Prophecy\Argument;
+use \ZipArchive;
+
+class ArchiveStepSpec extends ObjectBehavior
+{
+    /** @var string */
+    private $directory;
+
+    public function let(
+        EventDispatcherInterface $dispatcher,
+        JobRepositoryInterface $respository,
+        ZipArchive $zip
+    ) {
+        $this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'spec' . DIRECTORY_SEPARATOR;
+
+        $this->beConstructedWith(['job_test_name'], $dispatcher, $respository, $zip);
+    }
+
+    // @codingStandardsIgnoreLine
+    public function it_executes_with_success(
+        StepExecution $execution,
+        $dispatcher,
+        $respository,
+        JobParameters $jobParameters,
+        BatchStatus $status,
+        ExitStatus $exitStatus,
+        $zip
+    ) {
+        $jobParameters->get('exportDir')->willReturn($this->directory);
+        $execution->getJobParameters()->willReturn($jobParameters);
+        $execution->getJobExecution()->willReturn($execution);
+
+        # before
+        $execution->getStatus()->willReturn($status);
+        $status->getValue()->willReturn(BatchStatus::STARTING);
+        $dispatcher->dispatch(EventInterface::BEFORE_STEP_EXECUTION, Argument::any())->shouldBeCalled();
+        $execution->setStartTime(Argument::any())->shouldBeCalled();
+        $execution->setStatus(Argument::any())->shouldBeCalled();
+        $execution->upgradeStatus(Argument::any())->shouldBeCalled();
+
+        $zip->open(Argument::any(), Argument::any())->willReturn(true);
+        $zip->addPattern(Argument::any(), Argument::any(), Argument::any())->willReturn(array(
+            '/tmp/metadata.json',
+            '/tmp/anotherfile.csv'
+        ));
+        $zip->close()->shouldBeCalled();
+
+        $execution->addSummaryInfo('zip_location', $this->directory.'export.zip')->shouldBeCalled();
+
+        # after
+        $execution->getExitStatus()->willReturn($exitStatus);
+        $exitStatus->getExitCode()->willReturn(ExitStatus::COMPLETED);
+        $execution->isTerminateOnly()->willReturn(false);
+        $execution->upgradeStatus(Argument::any())->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::STEP_EXECUTION_SUCCEEDED, Argument::any())->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::STEP_EXECUTION_COMPLETED, Argument::any())->shouldBeCalled();
+        $execution->setEndTime(Argument::any())->shouldBeCalled();
+        $execution->setExitStatus(Argument::any())->shouldBeCalled();
+
+        $this->execute($execution);
+    }
+
+    // @codingStandardsIgnoreLine
+    public function it_throws_add_failure_exception_when_there_is_none_mathed_files(
+        StepExecution $execution,
+        $dispatcher,
+        $respository,
+        JobParameters $jobParameters,
+        BatchStatus $status,
+        ExitStatus $exitStatus,
+        $zip
+    ) {
+        
+        $jobParameters->get('exportDir')->willReturn($this->directory);
+        $execution->getJobParameters()->willReturn($jobParameters);
+        $execution->getJobExecution()->willReturn($execution);
+
+        # before
+        $execution->getStatus()->willReturn($status);
+        $status->getValue()->willReturn(BatchStatus::STARTING);
+        $dispatcher->dispatch(EventInterface::BEFORE_STEP_EXECUTION, Argument::any())->shouldBeCalled();
+        $execution->setStartTime(Argument::any())->shouldBeCalled();
+        $execution->setStatus(Argument::any())->shouldBeCalled();
+        $execution->upgradeStatus(Argument::any())->shouldBeCalled();
+
+        $zip->open(Argument::any(), Argument::any())->willReturn(true);
+
+        // return empty array
+        $zip->addPattern(Argument::any(), Argument::any(), Argument::any())->willReturn(array());
+        
+        $execution->addFailureException(Argument::any())->shouldBeCalled();
+
+        # after
+        $execution->getExitStatus()->willReturn($exitStatus);
+        $exitStatus->getExitCode()->willReturn(ExitStatus::COMPLETED);
+        $execution->isTerminateOnly()->willReturn(false);
+        $execution->upgradeStatus(Argument::any())->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::STEP_EXECUTION_SUCCEEDED, Argument::any())->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::STEP_EXECUTION_COMPLETED, Argument::any())->shouldBeCalled();
+        $execution->setEndTime(Argument::any())->shouldBeCalled();
+        $execution->setExitStatus(Argument::any())->shouldBeCalled();
+
+        $this->execute($execution);
+    }
+}

--- a/spec/Step/MetadataStepSpec.php
+++ b/spec/Step/MetadataStepSpec.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace spec\Snowio\Bundle\CsvConnectorBundle\Step;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Job\BatchStatus;
+use Akeneo\Component\Batch\Job\ExitStatus;
+use Akeneo\Component\Batch\Event\EventInterface;
+use Akeneo\Component\Batch\Job\JobParameters;
+use Akeneo\Component\Batch\Model\JobExecution;
+use Akeneo\Component\Batch\Model\JobInstance;
+use Prophecy\Argument;
+use Symfony\Component\Filesystem\Filesystem;
+
+class MetadataStepSpec extends ObjectBehavior
+{
+    /** @var Filesystem */
+    private $filesystem;
+
+    /** @var string */
+    private $directory;
+
+    public function let(
+        EventDispatcherInterface $dispatcher,
+        JobRepositoryInterface $respository
+    ) {
+        $this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'spec' . DIRECTORY_SEPARATOR;
+        $this->filesystem = new Filesystem();
+        $this->filesystem->mkdir($this->directory);
+
+        $this->beConstructedWith(['job_test_name'], $dispatcher, $respository);
+    }
+
+    // @codingStandardsIgnoreLine
+    function it_executes_with_success(
+        StepExecution $execution,
+        $dispatcher,
+        JobParameters $jobParameters,
+        BatchStatus $status,
+        ExitStatus $exitStatus,
+        JobInstance $jobInstance,
+        JobExecution $jobExecution
+    ) {
+        $jobParameters->get('exportDir')->willReturn($this->directory);
+        $jobParameters->get('delimiter')->willReturn('abc');
+        $jobParameters->get('filters')->willReturn('abc');
+        $jobParameters->has('filters')->willReturn(true);
+        $jobParameters->get('enclosure')->willReturn('abc');
+        $jobParameters->get('withHeader')->willReturn('abc');
+        $jobParameters->get('decimalSeparator')->willReturn('abc');
+        $jobParameters->has('decimalSeparator')->willReturn(true);
+        $jobParameters->get('dateFormat')->willReturn('abc');
+        $jobParameters->has('dateFormat')->willReturn(true);
+        $jobParameters->get('with_media')->willReturn('abc');
+        $jobParameters->has('with_media')->willReturn(true);
+
+        $execution->getJobParameters()->willReturn($jobParameters);
+
+        $jobInstance->getJobName()->willReturn('Jobtest');
+        $jobExecution->getJobInstance()->willReturn($jobInstance);
+        $execution->getJobExecution()->willReturn($jobExecution);
+
+        # before
+        $execution->getStatus()->willReturn($status);
+        $status->getValue()->willReturn(BatchStatus::STARTING);
+        $dispatcher->dispatch(EventInterface::BEFORE_STEP_EXECUTION, Argument::any())->shouldBeCalled();
+        $execution->setStartTime(Argument::any())->shouldBeCalled();
+        $execution->setStatus(Argument::any())->shouldBeCalled();
+        $execution->upgradeStatus(Argument::any())->shouldBeCalled();
+
+        # my step logic assertions
+        $execution->addSummaryInfo('metadata_location', $this->directory.'metadata.json')->shouldBeCalled();
+
+        # after
+        $execution->getExitStatus()->willReturn($exitStatus);
+        $exitStatus->getExitCode()->willReturn(ExitStatus::COMPLETED);
+        $execution->isTerminateOnly()->willReturn(false);
+        $execution->upgradeStatus(Argument::any())->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::STEP_EXECUTION_SUCCEEDED, Argument::any())->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::STEP_EXECUTION_COMPLETED, Argument::any())->shouldBeCalled();
+        $execution->setEndTime(Argument::any())->shouldBeCalled();
+        $execution->setExitStatus(Argument::any())->shouldBeCalled();
+
+        $this->execute($execution);
+    }
+}

--- a/spec/Step/PostStepSpec.php
+++ b/spec/Step/PostStepSpec.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace spec\Snowio\Bundle\CsvConnectorBundle\Step;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Akeneo\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Component\Batch\Model\StepExecution;
+use Akeneo\Component\Batch\Job\BatchStatus;
+use Akeneo\Component\Batch\Job\ExitStatus;
+use Akeneo\Component\Batch\Event\EventInterface;
+use Akeneo\Component\Batch\Job\JobParameters;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\StreamInterface;
+use Prophecy\Argument;
+use Symfony\Component\Filesystem\Filesystem;
+
+class PostStepSpec extends ObjectBehavior
+{
+    /** @var Filesystem */
+    private $filesystem;
+
+    /** @var string */
+    private $directory;
+
+    public function let(
+        EventDispatcherInterface $dispatcher,
+        JobRepositoryInterface $respository,
+        Client $guzzle
+    ) {
+        $this->directory = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'spec' . DIRECTORY_SEPARATOR;
+        $this->filesystem = new Filesystem();
+
+        $this->beConstructedWith(['job_test_name'], $dispatcher, $respository, $guzzle);
+    }
+
+    public function letGo()
+    {
+        $this->filesystem->remove($this->directory);
+    }
+
+    // @codingStandardsIgnoreLine
+    function it_executes_with_success(
+        StepExecution $execution,
+        $dispatcher,
+        $respository,
+        JobParameters $jobParameters,
+        BatchStatus $status,
+        ExitStatus $exitStatus,
+        Client $guzzle,
+        Response $response,
+        StreamInterface $body
+    ) {
+        $jobParameters->get('endpoint')->willReturn('myendpointfortest');
+        $jobParameters->get('exportDir')->willReturn($this->directory);
+        $jobParameters->get('secretKey')->willReturn('abc');
+        $jobParameters->get('applicationId')->willReturn('999');
+
+        $file = $this->directory.'export.zip';
+        $resource = fopen($file, 'w+');
+
+        $execution->getJobParameters()->willReturn($jobParameters);
+        $execution->getJobExecution()->willReturn($execution);
+
+        # before
+        $execution->getStatus()->willReturn($status);
+        $status->getValue()->willReturn(BatchStatus::STARTING);
+        $dispatcher->dispatch(EventInterface::BEFORE_STEP_EXECUTION, Argument::any())->shouldBeCalled();
+        $execution->setStartTime(Argument::any())->shouldBeCalled();
+        $execution->setStatus(Argument::any())->shouldBeCalled();
+        $execution->upgradeStatus(Argument::any())->shouldBeCalled();
+
+        # my step logic assertions
+        $execution->addSummaryInfo('endpoint', 'myendpointfortest999')->shouldBeCalled();
+        $execution->addSummaryInfo('response_code', '204')->shouldBeCalled();
+        $execution->addSummaryInfo('response_body', 'data received')->shouldBeCalled();
+
+        $response->getStatusCode()->willReturn(204);
+
+        $body->getContents()->willReturn('data received');
+        $response->getBody()->willReturn($body);
+        $guzzle->request('POST', 'myendpointfortest999', Argument::any())->willReturn($response);
+
+        # after
+        $execution->getExitStatus()->willReturn($exitStatus);
+        $exitStatus->getExitCode()->willReturn(ExitStatus::COMPLETED);
+        $execution->isTerminateOnly()->willReturn(false);
+        $execution->upgradeStatus(Argument::any())->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::STEP_EXECUTION_SUCCEEDED, Argument::any())->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::STEP_EXECUTION_COMPLETED, Argument::any())->shouldBeCalled();
+        $execution->setEndTime(Argument::any())->shouldBeCalled();
+        $execution->setExitStatus(Argument::any())->shouldBeCalled();
+
+        $this->execute($execution);
+
+        //remove file after test
+        unlink($file);
+    }
+}


### PR DESCRIPTION
Summary
---------

Create Snow Akeneo bundle for Akeneo 2. This bundle creates a new snowio connector with two export profiles:

- Full export
- Partial export

Once an export has ran, all resulting CSV files are zipped and sent over to a snowio endpoint. This module is very similar to the Akeneo 1 snow bundle here: https://github.com/snowio/akeneo-bundle. The main difference in this bundle is that we now export `product_model` data instead of the now deprecated `variant_group`.

**Product Model Export**

In regards to `product_model` exports, it seems that both product and product_model exports use the same reader class to read in the data (`Pim\Component\Connector\Reader\Database\ProductReader`). This reader class works fine for product_model exports using the vanilla Akeneo connector as no filters are added, however for our snowio connector the product filters try to apply to the product_model data - causing a fatal exception. To resolve this, I have created a custom reader class for snow product_model exports. This custom reader class ensures no filters are used on product_model exports.