### PR TITLE
Fix rsyncOptions array caused PHP Notice (Array to string conversion)

### DIFF
--- a/Job/JobParameters/DefaultValuesProvider/DefaultValuesTrait.php
+++ b/Job/JobParameters/DefaultValuesProvider/DefaultValuesTrait.php
@@ -24,7 +24,7 @@ trait DefaultValuesTrait
             'rsyncDirectory'=> '',
             'rsyncUser'     => '',
             'rsyncHost'     => '',
-            'rsyncOptions'  => [],
+            'rsyncOptions'  => '',
         ], $simpleDefaults);
     }
 }


### PR DESCRIPTION
# Issue

PHP Notice error occurs when export media files. This is due to the array default value. It should be set as empty string instead.

```bash
$ bin/console akeneo:batch:job snow_complete_export

An error occurred during the export execution.

Error #0 in class Symfony\Component\Debug\Exception\ContextErrorException: Notice: Array to string conversion
```

# Apply the fix

After applied the patch, we need to:

Save the Job instance with a change (e.g., add a space to the rsyncOptions). This is because Akeneo detect change on save, if no change is detected, it ignores the save event and the new corrected default value will fail to save